### PR TITLE
Fix upsert plugin not working properly with nulls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 .rspec_status
 
 Gemfile.lock
+
+log

--- a/spec/plugins/upsert_spec.rb
+++ b/spec/plugins/upsert_spec.rb
@@ -8,7 +8,7 @@ end
 
 UpsertModel = Sequel::Model(:upsert_test)
 UpsertModel.create(name: "name", value: 1)
-UpsertModel.create(name: "name2", value: 3)
+UpsertModel.create(name: "name2", value: nil)
 
 RSpec.describe "upsert" do
   it "updates existing record" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,8 +22,10 @@ Dir["#{__dir__}/../lib/sequel/**/*.rb"].each { |f| require f }
 RSpec.configure do |config|
   config.example_status_persistence_file_path = ".rspec_status"
   config.disable_monkey_patching!
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
   config.after(:suite) { clean_database! }
 end

--- a/utils/database.rb
+++ b/utils/database.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
-::DB ||= Sequel.connect(ENV["DB_URL"] || "postgres://localhost/sequel_plugins")
+require "logger"
+
+DB = Sequel.connect(ENV["DB_URL"] || "postgres://localhost/sequel_plugins")
+DB.logger = Logger.new("log/db.log")
+
 Sequel::Model.db = DB
+
 DB.extension :pg_array
 DB.extension :pg_json
 DB.extension :pg_range


### PR DESCRIPTION
The generates WHERE expression was using != which doesn't work with nulls. Replaced that with `IS  DISTINCT FROM` so that generated SQL looks like this:

```sql
INSERT INTO "upsert_test" ("name", "value") VALUES ('name', 2) ON CONFLICT ("name") DO UPDATE SET "name" = "excluded"."name", "value" = "excluded"."value" WHERE ("upsert_test"."name" IS DISTINCT FROM "excluded"."name" OR "upsert_test"."value" IS DISTINCT FROM "excluded"."value") RETURNING NULL
```