### PR TITLE
money accessor plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,24 @@ item.price # => #<Money fractional:5000.0 currency:USD>
 item.get_column_value(:amount) # => 0.5e2
 ```
 
+## MoneyAccessors
+
+Enable: `Sequel::Model.plugin :money_accessors`
+
+Plugin for using money field keys as model properties.
+
+Example:
+
+```ruby
+class Order < Sequel::Model
+  money_accessor :amount, :currency
+end
+
+order = Order.create(amount: 200, currency: "EUR")
+order.amount # => #<Money fractional:20000.0 currency:RUB>
+order.currency # => "EUR"
+```
+
 ## StoreAccessors
 
 Enable: `Sequel::Model.plugin :store_accessors`

--- a/README.md
+++ b/README.md
@@ -239,9 +239,16 @@ item.get_column_value(:amount) # => 0.5e2
 
 ## MoneyAccessors
 
-Enable: `Sequel::Model.plugin :money_accessors`
+**Important:** requires `money` gem described above.
 
 Plugin for using money field keys as model properties.
+
+Enable:
+
+```ruby
+add_runtime_dependency "money"
+Sequel::Model.plugin :money_accessors
+````
 
 Examples of usage:
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ Enable: `Sequel::Model.plugin :money_accessors`
 
 Plugin for using money field keys as model properties.
 
-Example:
+Examples of usage:
+
+##### Money accessor
 
 ```ruby
 class Order < Sequel::Model
@@ -251,7 +253,34 @@ class Order < Sequel::Model
 end
 
 order = Order.create(amount: 200, currency: "EUR")
-order.amount # => #<Money fractional:20000.0 currency:RUB>
+order.amount # => #<Money fractional:20000.0 currency:EUR>
+order.currency # => "EUR"
+
+order.amount = Money.new(150, "RUB")
+order.amount # => #<Money fractional:150.0 currency:RUB>
+```
+
+##### Money setter
+
+```ruby
+class Order < Sequel::Model
+  money_setter :amount, :currency
+end
+
+order = Order.create(amount: 200, currency: "EUR")
+order.amount = Money.new(150, "RUB")
+order.currency # => "RUB"
+```
+
+##### Money getter
+
+```ruby
+class Order < Sequel::Model
+  money_getter :amount, :currency
+end
+
+order = Order.create(amount: 200, currency: "EUR")
+order.amount # => #<Money fractional:20000.0 currency:EUR>
 order.currency # => "EUR"
 ```
 

--- a/lib/sequel/plugins/money_accessors.rb
+++ b/lib/sequel/plugins/money_accessors.rb
@@ -30,7 +30,7 @@ module Sequel::Plugins::MoneyAccessors
         define_method(amount_column) do
           amount, currency = super(), send(currency_column)
           return unless amount && currency
-          Money[amount.to_d, currency]
+          Money.from_amount(amount.to_d, currency)
         end
       end
     end

--- a/lib/sequel/plugins/money_accessors.rb
+++ b/lib/sequel/plugins/money_accessors.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "money"
+
+# Creates accessors for money values
+module Sequel::Plugins::MoneyAccessors
+  MoneyClassRequired = Class.new(StandardError)
+
+  module ClassMethods
+    # Setup money accessor
+    #
+    # @param amount_column [Symbol] amount column
+    # @param currency_column [Symbol] currency column
+    # @example
+    #   class Order < Sequel::Model
+    #     money_accessor :amount, :currency
+    #   end
+    #
+    #   order = Order.create(amount: 200, currency: "EUR")
+    #   order.amount # => #<Money fractional:20000.0 currency:RUB>
+    #   order.currency # => "EUR"
+    def money_accessor(amount_column, currency_column)
+      money_getter(amount_column, currency_column)
+      money_setter(amount_column, currency_column)
+    end
+
+    def money_getter(amount_column, currency_column)
+      include_accessors_module!
+      @_money_accessors_module.module_eval do
+        define_method(amount_column) do
+          amount, currency = super(), send(currency_column)
+          return unless amount && currency
+          Money[amount.to_d, currency]
+        end
+      end
+    end
+
+    def money_setter(amount_column, currency_column)
+      include_accessors_module!
+      @_money_accessors_module.module_eval do
+        define_method("#{amount_column}=") do |value|
+          case value
+          when Money
+            amount = value.to_d
+            currency = value.currency.to_s
+          when nil
+            amount = currency = nil
+          else
+            raise MoneyClassRequired, "#{amount_column} value must be either Money instance or nil"
+          end
+
+          super(amount)
+          send("#{currency_column}=", currency)
+        end
+      end
+    end
+
+    private
+
+    def include_accessors_module!
+      return if defined?(@_money_accessors_module)
+      @_money_accessors_module = Module.new
+      prepend @_money_accessors_module
+    end
+  end
+end

--- a/lib/sequel/timestamp_migrator_undo_extension.rb
+++ b/lib/sequel/timestamp_migrator_undo_extension.rb
@@ -23,7 +23,7 @@ module Sequel
         ds.filter(column => filename).delete
       end
 
-      elapsed = format("%<time>0.6f", time: Tim.now - time)
+      elapsed = format("%<time>0.6f", time: Time.now - time)
       db.log_info("Finished undoing migration #{filename}, took #{elapsed} seconds")
     end
 

--- a/lib/sequel/timestamp_migrator_undo_extension.rb
+++ b/lib/sequel/timestamp_migrator_undo_extension.rb
@@ -23,7 +23,7 @@ module Sequel
         ds.filter(column => filename).delete
       end
 
-      elapsed = format("%0.6f", Time.now - time)
+      elapsed = format("%<0.6>f", Time.now - time)
       db.log_info("Finished undoing migration #{filename}, took #{elapsed} seconds")
     end
 

--- a/lib/sequel/timestamp_migrator_undo_extension.rb
+++ b/lib/sequel/timestamp_migrator_undo_extension.rb
@@ -23,7 +23,7 @@ module Sequel
         ds.filter(column => filename).delete
       end
 
-      elapsed = format("%<0.6>f", Time.now - time)
+      elapsed = format("%<time>0.6f", time: Tim.now - time)
       db.log_info("Finished undoing migration #{filename}, took #{elapsed} seconds")
     end
 

--- a/spec/plugins/money_accessors_spec.rb
+++ b/spec/plugins/money_accessors_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Sequel::Plugins::MoneyAccessors do
+RSpec.describe Sequel::Plugins::MoneyAccessors do
   before do
     DB.create_table(:test_orders) do
       column :amount, "numeric"
@@ -17,10 +17,10 @@ describe Sequel::Plugins::MoneyAccessors do
     end
   end
 
-  let(:order) { order_model.create(amount: Money[15, "USD"]) }
+  let(:order) { order_model.create(amount: Money.from_amount(15, "USD")) }
 
   it "stores column as Money instance" do
-    expect(order.amount).to eq_money(15, "USD")
+    expect(order.amount).to eq(Money.new(1500, "USD"))
     expect(order.billing_amount).to eq(nil)
 
     expect(order.values).to eq(
@@ -32,10 +32,10 @@ describe Sequel::Plugins::MoneyAccessors do
   end
 
   it "allows setting amount to nil" do
-    order.set(amount: nil, billing_amount: Money[25, "EUR"])
+    order.set(amount: nil, billing_amount: Money.from_amount(25, "USD"))
 
     expect(order.amount).to eq(nil)
-    expect(order.billing_amount).to eq_money(25, "EUR")
+    expect(order.billing_amount).to eq(Money.new(2500, "USD"))
 
     expect(order.values).to eq(
       amount: nil,

--- a/spec/plugins/money_accessors_spec.rb
+++ b/spec/plugins/money_accessors_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe Sequel::Plugins::MoneyAccessors do
   end
 
   it "allows setting amount to nil" do
-    order.set(amount: nil, billing_amount: Money.from_amount(25, "USD"))
+    order.set(amount: nil, billing_amount: Money.from_amount(25, "EUR"))
 
     expect(order.amount).to eq(nil)
-    expect(order.billing_amount).to eq(Money.new(2500, "USD"))
+    expect(order.billing_amount).to eq(Money.new(2500, "EUR"))
 
     expect(order.values).to eq(
       amount: nil,

--- a/spec/plugins/money_accessors_spec.rb
+++ b/spec/plugins/money_accessors_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+describe Sequel::Plugins::MoneyAccessors do
+  before do
+    DB.create_table(:test_orders) do
+      column :amount, "numeric"
+      column :currency, "text"
+      column :billing_amount, "float"
+      column :billing_currency, "text"
+    end
+  end
+
+  let(:order_model) do
+    Class.new(Sequel::Model(:test_orders)) do
+      money_accessor :amount, :currency
+      money_accessor :billing_amount, :billing_currency
+    end
+  end
+
+  let(:order) { order_model.create(amount: Money[15, "USD"]) }
+
+  it "stores column as Money instance" do
+    expect(order.amount).to eq_money(15, "USD")
+    expect(order.billing_amount).to eq(nil)
+
+    expect(order.values).to eq(
+      amount: 15,
+      currency: "USD",
+      billing_amount: nil,
+      billing_currency: nil,
+    )
+  end
+
+  it "allows setting amount to nil" do
+    order.set(amount: nil, billing_amount: Money[25, "EUR"])
+
+    expect(order.amount).to eq(nil)
+    expect(order.billing_amount).to eq_money(25, "EUR")
+
+    expect(order.values).to eq(
+      amount: nil,
+      currency: nil,
+      billing_amount: 25,
+      billing_currency: "EUR",
+    )
+  end
+
+  context "invalid value provided to setter" do
+    it "raises error" do
+      expect { order_model.new(amount: 15) }.to raise_error(
+        Sequel::Plugins::MoneyAccessors::MoneyClassRequired,
+        "amount value must be either Money instance or nil",
+      )
+    end
+  end
+end

--- a/spec/plugins/money_accessors_spec.rb
+++ b/spec/plugins/money_accessors_spec.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.describe Sequel::Plugins::MoneyAccessors do
-  before do
-    DB.create_table(:test_orders) do
-      column :amount, "numeric"
-      column :currency, "text"
-      column :billing_amount, "float"
-      column :billing_currency, "text"
-    end
-  end
+DB.create_table(:test_orders) do
+  column :amount, "numeric"
+  column :currency, "text"
+  column :billing_amount, "float"
+  column :billing_currency, "text"
+end
 
+RSpec.describe Sequel::Plugins::MoneyAccessors do
   let(:order_model) do
     Class.new(Sequel::Model(:test_orders)) do
       money_accessor :amount, :currency

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require "sequel"
 require "pry"
 require_relative "../utils/database"
 
-Dir["#{__dir__}/../lib/sequel/**/*.rb"].each { |f| require f }
+Dir["#{__dir__}/../lib/sequel/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.example_status_persistence_file_path = ".rspec_status"

--- a/umbrellio-sequel-plugins.gemspec
+++ b/umbrellio-sequel-plugins.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sequel"
-  spec.add_runtime_dependency "money"
+  spec.add_runtime_dependency "sequel"
   spec.add_runtime_dependency "symbiont-ruby", ">= 0.6"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "money"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"

--- a/umbrellio-sequel-plugins.gemspec
+++ b/umbrellio-sequel-plugins.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sequel"
   spec.add_dependency "money"
+  spec.add_dependency "sequel"
   spec.add_runtime_dependency "symbiont-ruby", ">= 0.6"
 
   spec.add_development_dependency "bundler"

--- a/umbrellio-sequel-plugins.gemspec
+++ b/umbrellio-sequel-plugins.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "money"
   spec.add_dependency "sequel"
+  spec.add_runtime_dependency "money"
   spec.add_runtime_dependency "symbiont-ruby", ">= 0.6"
 
   spec.add_development_dependency "bundler"

--- a/umbrellio-sequel-plugins.gemspec
+++ b/umbrellio-sequel-plugins.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "sequel"
+  spec.add_dependency "money"
   spec.add_runtime_dependency "symbiont-ruby", ">= 0.6"
 
   spec.add_development_dependency "bundler"

--- a/utils/database.rb
+++ b/utils/database.rb
@@ -24,6 +24,7 @@ Sequel.extension :pg_range_ops
 
 Sequel::Model.plugin :duplicate
 Sequel::Model.plugin :get_column_value
+Sequel::Model.plugin :money_accessors
 Sequel::Model.plugin :store_accessors
 Sequel::Model.plugin :synchronize
 Sequel::Model.plugin :upsert


### PR DESCRIPTION
Plugin for using money field keys as model properties.
Example:
```ruby
class Order < Sequel::Model
  money_accessor :amount, :currency
end

order = Order.create(amount: 200, currency: "EUR")
order.amount # => #<Money fractional:20000.0 currency:RUB>
order.currency # => "EUR"
```