### PR TITLE
Support for configurable plugins and extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] 2020-04-21
+### Added
+- Support for configurable extensions and plugins;
+  - `Sequel.extension(:deferrable_foreign_keys)` now supports `by_default` option to support the
+    global default `deferrable:` value (`true` by default);
+
 ## [0.4.0] 2019-11-18
 ### Added
 - `Sequel.extension(:deferrable_foreign_keys)` - makes foreign keys constraints deferrable by default;

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     umbrellio-sequel-plugins (0.4.0)
+      qonfig
       sequel
       symbiont-ruby (>= 0.6)
 
@@ -34,12 +35,13 @@ GEM
     money (6.13.7)
       i18n (>= 0.6.4, <= 2)
     parallel (1.19.1)
-    parser (2.7.1.0)
+    parser (2.7.1.1)
       ast (~> 2.4.0)
     pg (1.2.3)
     pry (0.13.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    qonfig (0.24.1)
     rack (2.2.2)
     rainbow (3.0.0)
     rake (13.0.1)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ And then execute:
 # Tools
 - `TimestampMigratorUndoExtension`
 
+
+## Configuration
+
+Global config: `Umbrellio::SequelPlugins.config` (works via [Qonfig](https://github.com/0exp/qonfig) gem);
+- `Umbrellio::SequelPlugins['extensions']` - global extensions config;
+- `Umbrellio::SequelPlugins['plugins']` - global plugins config;
+
 ## CurrencyRates
 
 Plugin for joining currency rates table to any other table and money exchange.
@@ -156,6 +163,10 @@ Enable: `Sequel.extension(:deferrable_foreign_keys)`
 
 Makes foreign keys constraints deferrable (`DEFERABLE INITIALLY DEFERRED`) by default.
 
+Configurable options:
+
+- `"extensions.deferrable_foreign_keys.by_default"` - makes all foreign keys globally deferrable (or not) (`true` by default);
+
 Example:
 
 ```ruby
@@ -185,7 +196,7 @@ OR
 ```ruby
 # wives attributes: id (pk), husband_id (fk)
 # husbands attributes: id (pk), wife_id (fk)
- 
+
 Wife = Sequel::Model(:wives)
 Husband = Sequel::Model(:husbands)
 

--- a/lib/sequel/extensions/deferrable_foreign_keys.rb
+++ b/lib/sequel/extensions/deferrable_foreign_keys.rb
@@ -3,7 +3,8 @@
 module Sequel
   module CreateTableDefaultDeferrable
     def foreign_key(name, table = nil, opts = nil)
-      patch = { deferrable: true }
+      deferrable = ::Umbrellio::SequelPlugins["extensions.deferrable_foreign_keys.by_default"]
+      patch = { deferrable: deferrable }
       opts = opts.nil? ? patch : patch.merge(opts)
       super(name, table, opts)
     end
@@ -11,7 +12,8 @@ module Sequel
 
   module AlterTableDefaultDeferrable
     def add_foreign_key(name, table, opts = nil)
-      patch = { deferrable: true }
+      deferrable = ::Umbrellio::SequelPlugins["extensions.deferrable_foreign_keys.by_default"]
+      patch = { deferrable: deferrable }
       opts = opts.nil? ? patch : patch.merge(opts)
       super(name, table, opts)
     end

--- a/lib/umbrellio_sequel_plugins.rb
+++ b/lib/umbrellio_sequel_plugins.rb
@@ -3,9 +3,11 @@
 require "qonfig"
 
 module SequelPlugins
+  # :nocov:
   if defined?(::Rails)
     Engine = Class.new(::Rails::Engine)
   end
+  # :nocov:
 end
 
 module Umbrellio

--- a/lib/umbrellio_sequel_plugins.rb
+++ b/lib/umbrellio_sequel_plugins.rb
@@ -1,7 +1,46 @@
 # frozen_string_literal: true
 
+require "qonfig"
+
 module SequelPlugins
   if defined?(::Rails)
     Engine = Class.new(::Rails::Engine)
+  end
+end
+
+module Umbrellio
+  module SequelPlugins
+    include Qonfig::Configurable
+
+    class << self
+      # @param config_key [String, Symbol]
+      # @return [Qonfig::Settings]
+      def [](config_key)
+        config[config_key]
+      end
+    end
+
+    configuration do
+      setting :extensions do
+        setting :currency_rates, {}
+        setting :methods_in_migrations, {}
+        setting :pg_tools, {}
+        setting :slave, {}
+        setting :synchronize, {}
+        setting :deferrable_foreign_keys do
+          setting :by_default, true
+        end
+      end
+
+      setting :plugins do
+        setting :duplicate, {}
+        setting :get_column_value, {}
+        setting :money_accessors, {}
+        setting :store_accessors, {}
+        setting :synchronize, {}
+        setting :upsert, {}
+        setting :with_lock, {}
+      end
+    end
   end
 end

--- a/spec/extensions/deferrable_foreign_keys_spec.rb
+++ b/spec/extensions/deferrable_foreign_keys_spec.rb
@@ -8,12 +8,20 @@ def create_table_with_foreign_key(name, fk_name, fk_reference, deferrable: true)
   end
 end
 
+def configurable_create_table_with_foreign_key(name, fk_name, fk_reference)
+  DB.create_table!(name) { foreign_key fk_name, fk_reference }
+end
+
 def alter_table_add_foreign_key(name, fk_name, fk_reference, deferrable: true)
   if deferrable
     DB.alter_table(name) { add_foreign_key fk_name, fk_reference }
   else
     DB.alter_table(name) { add_foreign_key fk_name, fk_reference, deferrable: false }
   end
+end
+
+def configurable_alter_table_add_foreign_key(name, fk_name, fk_reference)
+  DB.alter_table(name) { add_foreign_key fk_name, fk_reference }
 end
 
 def foreign_keys_deferrable?(*tables)
@@ -41,31 +49,13 @@ DB.create_table!(:authors) { primary_key :id }
 DB.create_table!(:publishers) { primary_key :id }
 
 RSpec.describe "deferrable_foreign_keys" do
-  before do
-    create_table_with_foreign_key(:books, :author_id, :authors, deferrable: deferrable)
-    create_table_with_foreign_key(:journals, :author_id, :authors, deferrable: deferrable)
-  end
-
-  let(:deferrable) { true }
-
-  it_behaves_like "fk constraints deferrable by default"
-
-  context "deferrable explicitly denied" do
-    let(:deferrable) { false }
-
-    it_behaves_like "fk constraints not deferrable"
-  end
-
-  context "when table is altered" do
+  describe "manual way" do
     before do
-      alter_table_add_foreign_key(:books, :publisher_id, :publishers, deferrable: deferrable)
-      alter_table_add_foreign_key(:journals, :publisher_id, :publishers, deferrable: deferrable)
+      create_table_with_foreign_key(:books, :author_id, :authors, deferrable: deferrable)
+      create_table_with_foreign_key(:journals, :author_id, :authors, deferrable: deferrable)
     end
 
-    after do
-      DB.alter_table(:books) { drop_foreign_key :publisher_id }
-      DB.alter_table(:journals) { drop_foreign_key :publisher_id }
-    end
+    let(:deferrable) { true }
 
     it_behaves_like "fk constraints deferrable by default"
 
@@ -73,6 +63,52 @@ RSpec.describe "deferrable_foreign_keys" do
       let(:deferrable) { false }
 
       it_behaves_like "fk constraints not deferrable"
+    end
+
+    context "when table is altered" do
+      before do
+        alter_table_add_foreign_key(:books, :publisher_id, :publishers, deferrable: deferrable)
+        alter_table_add_foreign_key(:journals, :publisher_id, :publishers, deferrable: deferrable)
+      end
+
+      after do
+        DB.alter_table(:books) { drop_foreign_key :publisher_id }
+        DB.alter_table(:journals) { drop_foreign_key :publisher_id }
+      end
+
+      it_behaves_like "fk constraints deferrable by default"
+
+      context "deferrable explicitly denied" do
+        let(:deferrable) { false }
+
+        it_behaves_like "fk constraints not deferrable"
+      end
+    end
+  end
+
+  describe "configurable way" do
+    context "non-deferrable by default" do
+      before do
+        ::Umbrellio::SequelPlugins.config["extensions.deferrable_foreign_keys.by_default"] = false
+        configurable_create_table_with_foreign_key(:books, :author_id, :authors)
+        configurable_create_table_with_foreign_key(:journals, :author_id, :authors)
+      end
+
+      after do
+        ::Umbrellio::SequelPlugins.config["extensions.deferrable_foreign_keys.by_default"] = true
+      end
+
+      it_behaves_like "fk constraints not deferrable"
+    end
+
+    context "deferrable by default" do
+      before do
+        ::Umbrellio::SequelPlugins.config["extensions.deferrable_foreign_keys.by_default"] = true
+        configurable_create_table_with_foreign_key(:books, :author_id, :authors)
+        configurable_create_table_with_foreign_key(:journals, :author_id, :authors)
+      end
+
+      it_behaves_like "fk constraints deferrable by default"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require "bundler/setup"
 require "sequel"
 require "pry"
 require_relative "../utils/database"
+require_relative "../lib/umbrellio-sequel-plugins"
 
 Dir["#{__dir__}/../lib/sequel/**/*.rb"].sort.each { |f| require f }
 

--- a/umbrellio-sequel-plugins.gemspec
+++ b/umbrellio-sequel-plugins.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "qonfig"
   spec.add_runtime_dependency "sequel"
   spec.add_runtime_dependency "symbiont-ruby", ">= 0.6"
 


### PR DESCRIPTION
- global config: `Umbrellio::SequelPlugins.config`
  - `extensions` set for sequel extensions;
  - `plugins` set for sequel plugins;
- works via [Qonfig](https://github.com/0exp/qonfig)
- first configurable plugin: `deferrable_foreign_keys`:
  - `extensions.deferrable_foreign_keys.by_default` (**true**)