### PR TITLE
Make attr_encrypted refresh attributes on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ Order.create(first_name: "Ivan")
 
 order = Order.create(first_name: "Ivan", last_name: "Smith",
                       secret_data: { "some_key" => "Some Value" })
-order.reload
 order.first_name # => "Ivan"
 order.secret_data # => { "some_key" => "Some Value" }
 ```

--- a/lib/sequel/plugins/attr_encrypted.rb
+++ b/lib/sequel/plugins/attr_encrypted.rb
@@ -83,7 +83,7 @@ module Sequel::Plugins::AttrEncrypted
       super(*args, **kwargs, &block).tap { _reset_encrypted_attrs_ivars }
     end
 
-    def reload(*args, **kwargs, &block)
+    def refresh(*args, **kwargs, &block)
       super(*args, **kwargs, &block).tap { _reset_encrypted_attrs_ivars }
     end
 

--- a/lib/sequel/plugins/attr_encrypted.rb
+++ b/lib/sequel/plugins/attr_encrypted.rb
@@ -79,12 +79,12 @@ module Sequel::Plugins::AttrEncrypted
   end
 
   module InstanceMethods
-    def save(*args, **kwargs, &block)
-      super(*args, **kwargs, &block).tap { _reset_encrypted_attrs_ivars }
+    def save(*)
+      super.tap { _reset_encrypted_attrs_ivars }
     end
 
-    def refresh(*args, **kwargs, &block)
-      super(*args, **kwargs, &block).tap { _reset_encrypted_attrs_ivars }
+    def refresh(*)
+      super.tap { _reset_encrypted_attrs_ivars }
     end
 
     private

--- a/lib/sequel/plugins/attr_encrypted.rb
+++ b/lib/sequel/plugins/attr_encrypted.rb
@@ -79,17 +79,17 @@ module Sequel::Plugins::AttrEncrypted
   end
 
   module InstanceMethods
-    def save(...)
-      super(...).tap { _reset_encrypted_attributes_ivars }
+    def save(*args, **kwargs, &block)
+      super(*args, **kwargs, &block).tap { _reset_encrypted_attrs_ivars }
     end
 
-    def reload(...)
-      super(...).tap { _reset_encrypted_attributes_ivars }
+    def reload(*args, **kwargs, &block)
+      super(*args, **kwargs, &block).tap { _reset_encrypted_attrs_ivars }
     end
 
     private
 
-    def _reset_encrypted_attributes_ivars
+    def _reset_encrypted_attrs_ivars
       self.class.instance_variable_get(:@_encrypted_attributes)&.each do |attr|
         instance_variable_set("@#{attr}", nil)
       end

--- a/lib/sequel/plugins/attr_encrypted.rb
+++ b/lib/sequel/plugins/attr_encrypted.rb
@@ -32,7 +32,6 @@ module Sequel::Plugins::AttrEncrypted
     #
     #   order = Order.create(first_name: "Ivan", last_name: "Smith",
     #                        secret_data: { "some_key" => "Some Value" })
-    #   order.reload
     #   order.first_name # => "Ivan"
     #   order.last_name # => "Smith"
     #   order.secret_data # => { "some_key" => "Some Value" }
@@ -80,12 +79,20 @@ module Sequel::Plugins::AttrEncrypted
   end
 
   module InstanceMethods
-    def reload
+    def save(...)
+      super(...).tap { _reset_encrypted_attributes_ivars }
+    end
+
+    def reload(...)
+      super(...).tap { _reset_encrypted_attributes_ivars }
+    end
+
+    private
+
+    def _reset_encrypted_attributes_ivars
       self.class.instance_variable_get(:@_encrypted_attributes)&.each do |attr|
         instance_variable_set("@#{attr}", nil)
       end
-
-      super
     end
   end
 end

--- a/spec/plugins/attr_encrypted_spec.rb
+++ b/spec/plugins/attr_encrypted_spec.rb
@@ -20,13 +20,11 @@ RSpec.describe Sequel::Plugins::AttrEncrypted do
   let(:secret_attrs) { %i[name secret_data] }
 
   it "stores only encrypted attributes" do
-    order.reload
     secret_attrs.each { |attr| expect(order[attr]).to be(nil) }
     secret_attrs.each { |attr| expect(order[:"encrypted_#{attr}"]).not_to be_empty }
   end
 
   it "encrypts and decrypts attributes correctly" do
-    order.reload
     secret_attrs.each { |attr| expect(order.public_send(attr)).to eq(public_send(attr)) }
   end
 
@@ -35,7 +33,6 @@ RSpec.describe Sequel::Plugins::AttrEncrypted do
     let(:secret_data) { nil }
 
     it "stores it correctly" do
-      order.reload
       expect(order.name).to eq(nil)
       expect(order.secret_data).to eq(nil)
     end
@@ -46,7 +43,6 @@ RSpec.describe Sequel::Plugins::AttrEncrypted do
     let(:secret_data) { "" }
 
     it "stores as nil" do
-      order.reload
       expect(order.name).to eq("")
       expect(order.secret_data).to eq("")
     end


### PR DESCRIPTION
Previously, you had to explicitly call `reload` in order to refresh plain attrs ivars.
Now it will be done after `save` method call too (so after any create, update routine).
Also, patch `refresh` instead of `reload` since sequel `reload` uses `refresh` internally and `refresh` is exposed to public.

Motivation:
Sequel always refreshes model attributes after any create, update routine.