### PR TITLE
Добавил savepoint в with_lock

### DIFF
--- a/lib/sequel/plugins/with_lock.rb
+++ b/lib/sequel/plugins/with_lock.rb
@@ -5,12 +5,12 @@ module Sequel::Plugins::WithLock
     # Execute block with lock
     #
     # @yield
-    def with_lock
+    def with_lock(savepoint: true)
       return yield if @__locked
       @__locked = true
 
       begin
-        db.transaction(savepoint: true) do
+        db.transaction(savepoint: savepoint) do
           lock!
           yield
         end

--- a/lib/sequel/plugins/with_lock.rb
+++ b/lib/sequel/plugins/with_lock.rb
@@ -10,7 +10,7 @@ module Sequel::Plugins::WithLock
       @__locked = true
 
       begin
-        db.transaction do
+        db.transaction(savepoint: true) do
           lock!
           yield
         end

--- a/spec/plugins/with_lock_spec.rb
+++ b/spec/plugins/with_lock_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "with_lock" do
 
   describe "field when error occurs" do
     context "with outer transaction" do
-      def field_with_outer_transaction
+      def update_model!
         DB.transaction do
           begin
             model.with_lock(savepoint: savepoint) do
@@ -42,15 +42,16 @@ RSpec.describe "with_lock" do
           rescue
           end
         end
-
-        model.reload.count
       end
+
+      subject { model.reload.count }
 
       context "with savepoint" do
         let(:savepoint) { true }
 
         it "rollbacks changes" do
-          expect(field_with_outer_transaction).to eq(0)
+          update_model!
+          expect(subject).to eq(0)
         end
       end
 
@@ -58,7 +59,8 @@ RSpec.describe "with_lock" do
         let(:savepoint) { false }
 
         it "doesn't rollback changes" do
-          expect(field_with_outer_transaction).to eq(1)
+          update_model!
+          expect(subject).to eq(1)
         end
       end
     end

--- a/spec/plugins/with_lock_spec.rb
+++ b/spec/plugins/with_lock_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe "with_lock" do
     expect(model.count).to eq(1)
   end
 
-  describe "counter when error occurs" do
+  describe "field when error occurs" do
     context "with outer transaction" do
-      subject do
+      def field_with_outer_transaction
         DB.transaction do
           begin
             model.with_lock(savepoint: savepoint) do
@@ -50,7 +50,7 @@ RSpec.describe "with_lock" do
         let(:savepoint) { true }
 
         it "rollbacks changes" do
-          expect(subject).to eq(0)
+          expect(field_with_outer_transaction).to eq(0)
         end
       end
 
@@ -58,7 +58,7 @@ RSpec.describe "with_lock" do
         let(:savepoint) { false }
 
         it "doesn't rollback changes" do
-          expect(subject).to eq(1)
+          expect(field_with_outer_transaction).to eq(1)
         end
       end
     end

--- a/spec/plugins/with_lock_spec.rb
+++ b/spec/plugins/with_lock_spec.rb
@@ -44,14 +44,14 @@ RSpec.describe "with_lock" do
         end
       end
 
-      subject { model.reload.count }
+      subject(:field) { model.reload.count }
 
       context "with savepoint" do
         let(:savepoint) { true }
 
         it "rollbacks changes" do
           update_model!
-          expect(subject).to eq(0)
+          expect(field).to eq(0)
         end
       end
 
@@ -60,7 +60,7 @@ RSpec.describe "with_lock" do
 
         it "doesn't rollback changes" do
           update_model!
-          expect(subject).to eq(1)
+          expect(field).to eq(1)
         end
       end
     end


### PR DESCRIPTION
При таком коде:

```ruby
DB.transaction do
  begin
    something.with_lock { do_something }
  rescue
  end
end
```

Можно ожидать, что do_something выполнится в транзакции, но в `with_lock` тоже вызывается DB.transaction.

По умолчанию в таком случае транзакция [реюзается](https://github.com/jeremyevans/sequel/blob/master/doc/transactions.rdoc#label-Nested+Transaction+Calls+-2F+Savepoints), то есть если ошибка пересечет границы `with_lock`, то ничего не произодйет.

Если же поставить в транзакцию внутри `with_lock` `savepoint: true`, то изменения, которые происходили в with_lock, ролбэкнутся при возникновении ошибки внутри блока.