### PR TITLE
Fix for railties in TruffleRuby

### DIFF
--- a/lib/umbrellio_sequel_plugins.rb
+++ b/lib/umbrellio_sequel_plugins.rb
@@ -2,6 +2,7 @@
 
 module SequelPlugins
   if defined?(::Rails)
-    Engine = Class.new(::Rails::Engine)
+    class Engine < ::Rails::Engine
+    end
   end
 end


### PR DESCRIPTION
Railties with TruffleRuby fails with error
```
truffleruby-22.2.0/lib/gems/gems/railties-6.1.6.1/lib/rails/engine.rb:696:in `find_root_with_flag': Could not find root path for SequelPlugins::Engine (RuntimeError)
```
This is somehow related with source file lookup, changing class definition to good old style fixes the error