### PR TITLE
Use jsonb concat in `store_accessors`

### DIFF
--- a/spec/plugins/store_accessors_spec.rb
+++ b/spec/plugins/store_accessors_spec.rb
@@ -1,18 +1,45 @@
 # frozen_string_literal: true
 
 DB.create_table :posts do
+  primary_key :id
+  column :data, :jsonb, default: "{}"
   column :metadata, :jsonb, default: "{}"
 end
 
 class Post < Sequel::Model(:posts)
-  store :metadata, :tags
+  store :data, :amount, :project_id
+  store :metadata, :tags, :marker
 end
 
 RSpec.describe "store_accessors" do
-  let(:post) { Post.create(tags: %w[first second]) }
+  let!(:post) { Post.create(tags: %w[first second], amount: 10) }
 
   it "stores tags as json" do
-    expect(post.metadata).to eq("tags" => %w[first second])
+    expect(post.amount).to eq(10)
+    expect(post.data).to eq("amount" => 10)
     expect(post.tags).to eq(%w[first second])
+    expect(post.metadata).to eq("tags" => %w[first second])
+  end
+
+  it "doesn't reload if unchanged" do
+    first_post = Post[post.id]
+    first_post.marker = true
+    first_post.save_changes
+    post.save_changes
+    expect(post.marker).to be_nil
+  end
+
+  it "safely updates" do
+    first_post = Post[post.id]
+    first_post.marker = true
+    first_post.project_id = 1
+    first_post.save_changes
+    post.tags = %w[first]
+    post.amount = 5
+    post.save_changes
+    expect(post.tags).to eq(%w[first])
+    expect(post.marker).to eq(true)
+    expect(post.amount).to eq(5)
+    expect(post.project_id).to eq(1)
   end
 end

--- a/utils/database.rb
+++ b/utils/database.rb
@@ -2,7 +2,7 @@
 
 require "logger"
 
-DB = Sequel.connect(ENV.fetch("DB_URL", "postgres://localhost/sequel_plugins"))
+DB = Sequel.connect(ENV.fetch("DB_URL", "postgres:///sequel_plugins"))
 DB.logger = Logger.new("log/db.log")
 
 Sequel::Model.db = DB


### PR DESCRIPTION
There are situations when store columns of model are overwritten.

For example:

```ruby
DB.create_table :posts do
  primary_key :id
  column :metadata, :jsonb, default: "{}"
end

class Post < Sequel::Model(:posts)
  store :metadata, :tags, :marker
end

post = Post.create(tags: %w[first second])
first_post = Post[post.id]
first_post.marker = true
first_post.save_changes
post.tags = %w[first]
post.save_changes

post.reload.marker # nil
```

I made use of jsonb concat in order to bypass such situations.