### PR TITLE
Use jsonb concat in `store_accessors`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    umbrellio-sequel-plugins (0.10.0)
+    umbrellio-sequel-plugins (0.11.0)
       sequel
       symbiont-ruby
 

--- a/README.md
+++ b/README.md
@@ -388,12 +388,20 @@ user.first_name # => "John"
 user.data # => {"first_name": "John"}
 ```
 
-Warning: direct update of column will patch it
+Warning! Direct update of column will patch it.
 
 Example:
 
 ```ruby
-user.update(data: { "last_name": "Wick" }) # => {"first_name": "John", "last_name": "Wick"}
+user.update(data: {"last_name": "Wick"})
+user.data # => {"first_name": "John", "last_name": "Wick"}
+```
+
+If you want to use with `dirty` plugin then add `dirty` after `store_accessors`:
+
+```ruby
+Sequel::Model.plugin :store_accessors
+Sequel::Model.plugin :dirty # Must be after store_accessors
 ```
 
 ## Synchronize

--- a/README.md
+++ b/README.md
@@ -372,8 +372,6 @@ order.currency # => "EUR"
 
 ## StoreAccessors
 
-Requires plugin `dirty`.
-
 Enable: `Sequel::Model.plugin :store_accessors`
 
 Plugin for using jsonb field keys as model properties.

--- a/README.md
+++ b/README.md
@@ -380,12 +380,20 @@ Example:
 
 ```ruby
 class User < Sequel::Model
-  store :data, :first_name
+  store :data, :first_name, :last_name
 end
 
 user = User.create(first_name: "John")
 user.first_name # => "John"
 user.data # => {"first_name": "John"}
+```
+
+Warning: direct update of column will patch it
+
+Example:
+
+```ruby
+user.update(data: { "last_name": "Wick" }) # => {"first_name": "John", "last_name": "Wick"}
 ```
 
 ## Synchronize

--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ order.currency # => "EUR"
 
 ## StoreAccessors
 
+Requires plugin `dirty`.
+
 Enable: `Sequel::Model.plugin :store_accessors`
 
 Plugin for using jsonb field keys as model properties.
@@ -386,22 +388,6 @@ end
 user = User.create(first_name: "John")
 user.first_name # => "John"
 user.data # => {"first_name": "John"}
-```
-
-Warning! Direct update of column will patch it.
-
-Example:
-
-```ruby
-user.update(data: {"last_name": "Wick"})
-user.data # => {"first_name": "John", "last_name": "Wick"}
-```
-
-If you want to use with `dirty` plugin then add `dirty` after `store_accessors`:
-
-```ruby
-Sequel::Model.plugin :store_accessors
-Sequel::Model.plugin :dirty # Must be after store_accessors
 ```
 
 ## Synchronize

--- a/lib/sequel/extensions/migration_transaction_options.rb
+++ b/lib/sequel/extensions/migration_transaction_options.rb
@@ -27,10 +27,14 @@ module MigratorExtension
       if migration.use_transactions.nil?
         @db.supports_transactional_ddl?
       else
+        # :nocov:
         migration.use_transactions
+        # :nocov:
       end
     else
+      # :nocov:
       @use_transactions
+      # :nocov:
     end
   end
 

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -102,7 +102,7 @@ module Sequel::Plugins::StoreAccessors
     def patched(column)
       initial_fields = initial_store_fields[column] || []
       initial_hashes = store_values_hashes[column] || {}
-      current = @values[column]
+      current = @values[column] || {}
 
       current.dup.delete_if do |k, v|
         initial_fields.include?(k) && initial_hashes[k] == v.hash
@@ -111,7 +111,7 @@ module Sequel::Plugins::StoreAccessors
 
     def deleted(column)
       initial_fields = initial_store_fields[column] || []
-      current = @values[column]
+      current = @values[column] || {}
 
       initial_fields.dup - current.keys
     end

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -65,6 +65,11 @@ module Sequel::Plugins::StoreAccessors
       refresh_initial_store
     end
 
+    def after_create
+      super
+      refresh_initial_store
+    end
+
     def calculate_initial_store
       @store_values_hashes || refresh_initial_store
     end
@@ -107,7 +112,7 @@ module Sequel::Plugins::StoreAccessors
 
     def refresh_initial_store
       return unless respond_to?(:store_columns)
-      store_values = @values.slice(store_columns)
+      store_values = @values.slice(*store_columns)
       @initial_store_fields = store_values.transform_values { |v| v.to_h.keys }
       @store_values_hashes = store_values.transform_values { |v| v.transform_values(&:hash) }
     end

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -60,7 +60,13 @@ module Sequel::Plugins::StoreAccessors
       super
       return unless respond_to?(:store_columns)
       send(:store_columns).each do |store_column|
-        json = Sequel.pg_jsonb_op(Sequel.function(:coalesce, Sequel[store_column], Sequel.pg_jsonb({})))
+        json = Sequel.pg_jsonb_op(
+          Sequel.function(
+            :coalesce,
+            Sequel[store_column],
+            Sequel.pg_jsonb({}),
+          ),
+        )
         updated = json.concat(send(store_column))
         send("#{store_column}=", updated) if changed_columns.include?(store_column)
       end
@@ -69,12 +75,13 @@ module Sequel::Plugins::StoreAccessors
     def after_update
       super
       return unless respond_to?(:store_columns)
-      _refresh_store_columns unless send(:store_columns).all?(Hash)
+      _refresh_store_columns unless send(:store_columns).all? { |c| send(c).is_a?(Hash) }
     end
 
     def _refresh_store_columns
       refreshed = _refresh_get(this) || raise(NoExistingObject, "Record not found")
       send(:store_columns).each do |store_column|
+        next if send(store_column).is_a?(Hash)
         @values[store_column] = refreshed[store_column]
       end
     end

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -77,8 +77,16 @@ module Sequel::Plugins::StoreAccessors
     def changed_columns
       changed = super
       return changed unless respond_to?(:store_columns)
-      store_changed = store_columns.select { |c| patched(c).any? || deleted(c).any? }
-      (changed + store_changed).uniq
+      changed = changed.dup if frozen?
+      store_columns.each do |col|
+        match = patched(col).empty? && deleted(col).empty?
+        if changed.include?(col)
+          changed.delete(col) if match
+        else
+          changed << col unless match
+        end
+      end
+      changed
     end
 
     private

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -61,11 +61,11 @@ module Sequel::Plugins::StoreAccessors
       return unless respond_to?(:store_columns)
       @_stores_current_values = {}
       send(:store_columns).each do |store_column|
+        current = send(store_column)
         @_stores_current_values[store_column] = current
         next unless changed_columns.include?(store_column)
 
         initial = initial_value(store_column)
-        current = send(store_column)
         patch = current.dup.delete_if { |k, v| initial.key?(k) && initial[k] == v }
         deleted = initial.dup.delete_if { |k, _| current.key?(k) }
 

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -71,7 +71,7 @@ module Sequel::Plugins::StoreAccessors
       super
       return unless respond_to?(:store_columns)
       send(:store_columns).each do |store_column|
-        json = Sequel.function(:coalesce, Sequel[store_column].pg_jsonb, Sequel.pg_jsonb({}))
+        json = Sequel.pg_jsonb(Sequel.function(:coalesce, Sequel[store_column], {}))
         updated = json.concat(send(store_column))
         send("#{store_column}=", updated, _force_update: true) if changed_columns.include?(store_column)
       end

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -65,6 +65,10 @@ module Sequel::Plugins::StoreAccessors
       refresh_initial_store
     end
 
+    def calculate_initial_store
+      @store_values_hashes || refresh_initial_store
+    end
+
     private
 
     def _update_without_checking(columns)
@@ -99,10 +103,6 @@ module Sequel::Plugins::StoreAccessors
     def _save_refresh
       super
       refresh_initial_store
-    end
-
-    def calculate_initial_store
-      @store_values_hashes || refresh_initial_store
     end
 
     def refresh_initial_store

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -112,7 +112,7 @@ module Sequel::Plugins::StoreAccessors
 
     def refresh_initial_store
       return unless respond_to?(:store_columns)
-      store_values = @values.slice(*store_columns)
+      store_values = @values.slice(*store_columns).to_h
       @initial_store_fields = store_values.transform_values { |v| v.to_h.keys }
       @store_values_hashes = store_values.transform_values { |v| v.transform_values(&:hash) }
     end

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -75,7 +75,7 @@ module Sequel::Plugins::StoreAccessors
     def _refresh_store_columns
       refreshed = _refresh_get(this) || raise(NoExistingObject, "Record not found")
       send(:store_columns).each do |store_column|
-        @values[store_column] = refreshed.send(store_column)
+        @values[store_column] = refreshed[store_column]
       end
     end
   end

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -17,7 +17,6 @@ module Sequel::Plugins::StoreAccessors
     #   user.data # => {"first_name": "John"}
     def store(column, *fields)
       include_accessors_module(column)
-      restrict_direct_update(column)
 
       fields.each do |field|
         define_store_getter(column, field)
@@ -39,16 +38,6 @@ module Sequel::Plugins::StoreAccessors
       @_store_accessors_module.define_method(:store_columns) { new_columns }
     end
 
-    def restrict_direct_update(column)
-      @_store_accessors_module.module_eval do
-        define_method("#{column}=") do |*args, **kwargs, &block|
-          force_update = kwargs.delete(:_force_update)
-          raise ArgumentError("Can't directly update store") unless force_update
-          super(*args, **kwargs, &block)
-        end
-      end
-    end
-
     def define_store_getter(column, field)
       @_store_accessors_module.module_eval do
         define_method(field) do
@@ -60,7 +49,7 @@ module Sequel::Plugins::StoreAccessors
     def define_store_setter(column, field)
       @_store_accessors_module.module_eval do
         define_method("#{field}=") do |value|
-          send("#{column}=", send(column).to_h.merge(field.to_s => value), _force_update: true)
+          send("#{column}=", send(column).to_h.merge(field.to_s => value))
         end
       end
     end
@@ -71,9 +60,9 @@ module Sequel::Plugins::StoreAccessors
       super
       return unless respond_to?(:store_columns)
       send(:store_columns).each do |store_column|
-        json = Sequel.pg_jsonb(Sequel.function(:coalesce, Sequel[store_column], {}))
+        json = Sequel.pg_jsonb_op(Sequel.function(:coalesce, Sequel[store_column], {}))
         updated = json.concat(send(store_column))
-        send("#{store_column}=", updated, _force_update: true) if changed_columns.include?(store_column)
+        send("#{store_column}=", updated) if changed_columns.include?(store_column)
       end
     end
 

--- a/lib/sequel/plugins/store_accessors.rb
+++ b/lib/sequel/plugins/store_accessors.rb
@@ -112,9 +112,9 @@ module Sequel::Plugins::StoreAccessors
 
     def refresh_initial_store
       return unless respond_to?(:store_columns)
-      store_values = @values.slice(*store_columns).to_h
+      store_values = @values.slice(*store_columns)
       @initial_store_fields = store_values.transform_values { |v| v.to_h.keys }
-      @store_values_hashes = store_values.transform_values { |v| v.transform_values(&:hash) }
+      @store_values_hashes = store_values.transform_values { |v| v.to_h.transform_values(&:hash) }
     end
 
     def initial_store_fields

--- a/spec/plugins/store_accessors_spec.rb
+++ b/spec/plugins/store_accessors_spec.rb
@@ -76,4 +76,12 @@ RSpec.describe "store_accessors" do
     expect(post.tags).to eq(%w[first second])
     expect(post.marker).to eq(true)
   end
+
+  it "updates from nil" do
+    post.update(data: nil)
+    post.amount = 20
+    post.save_changes
+    expect(post.reload.data).to eq("amount" => 20)
+    expect(post.amount).to eq(20)
+  end
 end

--- a/spec/plugins/store_accessors_spec.rb
+++ b/spec/plugins/store_accessors_spec.rb
@@ -37,7 +37,43 @@ RSpec.describe "store_accessors" do
 
   it "deletes fields" do
     post.update(data: {}, metadata: {})
-    expect(post.reload.tags).to eq(nil)
+    expect(post.reload.data).to eq({})
+    expect(post.metadata).to eq({})
+    expect(post.tags).to eq(nil)
     expect(post.amount).to eq(nil)
+  end
+
+  it "directly updates right" do
+    post.update(
+      data: { amount: 1, project_id: 2 },
+      metadata: { tags: %w[first], marker: true },
+    )
+    expect(post.reload.data.to_h).to eq("amount" => 1, "project_id" => 2)
+    expect(post.metadata.to_h).to eq("tags" => %w[first], "marker" => true)
+    expect(post.amount).to eq(1)
+    expect(post.project_id).to eq(2)
+    expect(post.tags).to eq(%w[first])
+    expect(post.marker).to eq(true)
+  end
+
+  it "updates fields" do
+    post.update(tags: %w[first])
+    expect(post.reload.metadata.to_h).to eq("tags" => %w[first])
+    expect(post.tags).to eq(%w[first])
+  end
+
+  it "updates on mutate fields" do
+    post.tags.push("third")
+    post.save_changes
+    expect(post.reload.metadata.to_h).to eq("tags" => %w[first second third])
+    expect(post.tags).to eq(%w[first second third])
+  end
+
+  it "updates on mutate store" do
+    post.metadata[:marker] = true
+    post.save_changes
+    expect(post.reload.metadata.to_h).to eq("tags" => %w[first second], "marker" => true)
+    expect(post.tags).to eq(%w[first second])
+    expect(post.marker).to eq(true)
   end
 end

--- a/spec/plugins/store_accessors_spec.rb
+++ b/spec/plugins/store_accessors_spec.rb
@@ -21,14 +21,6 @@ RSpec.describe "store_accessors" do
     expect(post.metadata).to eq("tags" => %w[first second])
   end
 
-  it "doesn't reload if unchanged" do
-    first_post = Post[post.id]
-    first_post.marker = true
-    first_post.save_changes
-    post.save_changes
-    expect(post.marker).to be_nil
-  end
-
   it "safely updates" do
     first_post = Post[post.id]
     first_post.marker = true
@@ -37,7 +29,7 @@ RSpec.describe "store_accessors" do
     post.tags = %w[first]
     post.amount = 5
     post.save_changes
-    expect(post.tags).to eq(%w[first])
+    expect(post.reload.tags).to eq(%w[first])
     expect(post.marker).to eq(true)
     expect(post.amount).to eq(5)
     expect(post.project_id).to eq(1)

--- a/spec/plugins/store_accessors_spec.rb
+++ b/spec/plugins/store_accessors_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "store_accessors" do
     expect(post.metadata).to eq("tags" => %w[first second])
   end
 
-  it "safely updates" do
+  it "updates only changed" do
     first_post = Post[post.id]
     first_post.marker = true
     first_post.project_id = 1
@@ -33,5 +33,11 @@ RSpec.describe "store_accessors" do
     expect(post.marker).to eq(true)
     expect(post.amount).to eq(5)
     expect(post.project_id).to eq(1)
+  end
+
+  it "deletes fields" do
+    post.update(data: {}, metadata: {})
+    expect(post.reload.tags).to eq(nil)
+    expect(post.amount).to eq(nil)
   end
 end

--- a/spec/plugins/store_accessors_spec.rb
+++ b/spec/plugins/store_accessors_spec.rb
@@ -1,18 +1,45 @@
 # frozen_string_literal: true
 
 DB.create_table :posts do
+  primary_key :id
+  column :data, :jsonb, default: "{}"
   column :metadata, :jsonb, default: "{}"
 end
 
 class Post < Sequel::Model(:posts)
-  store :metadata, :tags
+  store :data, :amount, :project_id
+  store :metadata, :tags, :marker
 end
 
 RSpec.describe "store_accessors" do
-  let(:post) { Post.create(tags: %w[first second]) }
+  let!(:post) { Post.create(tags: %w[first second], amount: 10) }
 
   it "stores tags as json" do
-    expect(post.metadata).to eq("tags" => %w[first second])
+    expect(post.amount).to eq(10)
+    expect(post.data).to eq("amount" => 10)
     expect(post.tags).to eq(%w[first second])
+    expect(post.metadata).to eq("tags" => %w[first second])
+  end
+
+  it "doesn't reload if unchanged" do
+    first_post = Post[post.id]
+    first_post.marker = true
+    first_post.save_changes
+    post.save_changes
+    expect(post.marker).to be_nil
+  end
+
+  it "safely updates" do
+    first_post = Post[post.id]
+    first_post.marker = true
+    first_post.project_id = 1
+    first_post.save_changes
+    post.tags = %w[first]
+    post.amount = 5
+    post.save_changes
+    expect(post.tags).to eq(%w[first])
+    expect(post.marker).to eq(true)
+    expect(post.amount).to eq(5)
+    expect(post.project_id).to eq(1)
   end
 end

--- a/umbrellio-sequel-plugins.gemspec
+++ b/umbrellio-sequel-plugins.gemspec
@@ -4,7 +4,7 @@ lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  gem_version = "0.10.0"
+  gem_version = "0.11.0"
 
   if ENV.fetch("PUBLISH_JOB", nil)
     release_version = "#{gem_version}.#{ENV.fetch("GITHUB_RUN_NUMBER")}"

--- a/utils/database.rb
+++ b/utils/database.rb
@@ -2,7 +2,7 @@
 
 require "logger"
 
-DB = Sequel.connect(ENV.fetch("DB_URL", "postgres://localhost/sequel_plugins"))
+DB = Sequel.connect(ENV.fetch("DB_URL", "postgres:///sequel_plugins"))
 DB.logger = Logger.new("log/db.log")
 
 Sequel::Model.db = DB

--- a/utils/database.rb
+++ b/utils/database.rb
@@ -24,7 +24,6 @@ Sequel.extension :pg_json_ops
 Sequel.extension :pg_range_ops
 
 Sequel::Model.plugin :attr_encrypted
-Sequel::Model.plugin :dirty
 Sequel::Model.plugin :duplicate
 Sequel::Model.plugin :get_column_value
 Sequel::Model.plugin :money_accessors

--- a/utils/database.rb
+++ b/utils/database.rb
@@ -24,6 +24,7 @@ Sequel.extension :pg_json_ops
 Sequel.extension :pg_range_ops
 
 Sequel::Model.plugin :attr_encrypted
+Sequel::Model.plugin :dirty
 Sequel::Model.plugin :duplicate
 Sequel::Model.plugin :get_column_value
 Sequel::Model.plugin :money_accessors


### PR DESCRIPTION
There are situations when store columns of model are overwritten. It happens because all columns are saved, even that didn't changed.

For example:

```ruby
DB.create_table :posts do
  primary_key :id
  column :metadata, :jsonb, default: "{}"
end

class Post < Sequel::Model(:posts)
  store :metadata, :tags, :marker
end

post = Post.create(tags: %w[first second])
first_post = Post[post.id]
first_post.marker = true
first_post.save_changes
post.tags = %w[first]
post.save_changes

post.reload.marker # nil
```

In my PR only changed fields of jsonb are updated.