### PR TITLE
async_thread_pool extension on concurrent ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     umbrellio-sequel-plugins (0.17.2)
+      concurrent-ruby
       sequel
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    umbrellio-sequel-plugins (0.17.2)
+    umbrellio-sequel-plugins (0.18.0)
       concurrent-ruby
       sequel
 

--- a/lib/sequel/extensions/concurrent_thread_pool.rb
+++ b/lib/sequel/extensions/concurrent_thread_pool.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module Sequel
+  # https://github.com/jeremyevans/sequel/blob/master/lib/sequel/extensions/async_thread_pool.rb
+  module Database::ConcurrentThreadPool
+
+    # Base proxy: delegates all method calls to the resolved async value.
+    class BaseProxy < BasicObject
+      def method_missing(*args, &block)
+        __value.public_send(*args, &block)
+      end
+
+      # :nocov:
+      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
+      # :nocov:
+
+      def respond_to_missing?(*args)
+        __value.respond_to?(*args)
+      end
+
+      [:!, :==, :!=, :instance_eval, :instance_exec].each do |method|
+        define_method(method) do |*args, &block|
+          __value.public_send(method, *args, &block)
+        end
+      end
+    end
+
+    # Default proxy: schedules block via Concurrent::Future, blocks on first access.
+    class Proxy < BaseProxy
+      def initialize(executor, &block)
+        @future = ::Concurrent::Future.execute(executor: executor, &block)
+      end
+
+      def __value
+        @future.value!
+      end
+    end
+
+    # Preemptable proxy: calling thread runs the block if the pool hasn't started it yet.
+    class PreemptableProxy < BaseProxy
+      def initialize(executor, &block)
+        @mutex = ::Mutex.new
+        @block = block
+        @done = false
+        @result = nil
+        @error = nil
+
+        executor.post { __run }
+      end
+
+      def __value
+        error, result = @mutex.synchronize do
+          __execute unless @done
+          [@error, @result]
+        end
+        ::Kernel.raise error if error
+        result
+      end
+
+      private
+
+      def __run
+        @mutex.synchronize { __execute unless @done }
+      end
+
+      def __execute
+        @result = @block.call
+      rescue ::Exception => e
+        @error = e
+      ensure
+        @done = true
+      end
+    end
+
+    module DatabaseMethods
+      def self.extended(db)
+        db.instance_exec do
+          case pool.pool_type
+          when :single, :sharded_single
+            raise Error, "cannot load async_thread_pool extension if using single or sharded_single connection pool"
+          end
+
+          executor, owned = if opts[:async_thread_executor]
+            [opts[:async_thread_executor], false]
+          elsif opts[:num_async_threads]
+            num = typecast_value_integer(opts[:num_async_threads])
+            raise Error, "must have positive number for num_async_threads" if num <= 0
+            [::Concurrent::ThreadPoolExecutor.new(
+              min_threads: num,
+              max_threads: num,
+              max_queue: 0,
+              fallback_policy: :abort,
+            ), true]
+          else
+            [::Concurrent.global_io_executor, false]
+          end
+
+          proxy_klass = typecast_value_boolean(opts[:preempt_async_thread]) ? PreemptableProxy : Proxy
+
+          define_singleton_method(:async_job_class) { proxy_klass }
+          define_singleton_method(:async_thread_executor) { executor }
+
+          ObjectSpace.define_finalizer(db, proc { executor.shutdown }) if owned
+
+          extend_datasets(DatasetMethods)
+        end
+      end
+
+      private
+
+      def async_run(&block)
+        async_job_class.new(async_thread_executor, &block)
+      end
+    end
+
+    ASYNC_METHODS = (
+      [:all?, :any?, :drop, :entries, :grep_v, :include?, :inject, :member?, :minmax,
+       :none?, :one?, :reduce, :sort, :take, :tally, :to_a, :to_h, :uniq, :zip] & Enumerable.instance_methods
+    ) + (Dataset::ACTION_METHODS - [:map, :paged_each])
+
+    ASYNC_BLOCK_METHODS = (
+      [:collect, :collect_concat, :detect, :drop_while, :each_cons, :each_entry, :each_slice,
+       :each_with_index, :each_with_object, :filter_map, :find, :find_all, :find_index,
+       :flat_map, :max_by, :min_by, :minmax_by, :partition, :reject, :reverse_each,
+       :sort_by, :take_while] & Enumerable.instance_methods
+    ) + [:paged_each]
+
+    ASYNC_ARGS_OR_BLOCK_METHODS = [:map]
+
+    module DatasetMethods
+      def self.define_async_method(mod, method)
+        mod.send(:define_method, method) do |*args, &block|
+          if @opts[:async]
+            ds = sync
+            db.send(:async_run) { ds.send(method, *args, &block) }
+          else
+            super(*args, &block)
+          end
+        end
+      end
+
+      def self.define_async_block_method(mod, method)
+        mod.send(:define_method, method) do |*args, &block|
+          if block && @opts[:async]
+            ds = sync
+            db.send(:async_run) { ds.send(method, *args, &block) }
+          else
+            super(*args, &block)
+          end
+        end
+      end
+
+      def self.define_async_args_or_block_method(mod, method)
+        mod.send(:define_method, method) do |*args, &block|
+          if (block || !args.empty?) && @opts[:async]
+            ds = sync
+            db.send(:async_run) { ds.send(method, *args, &block) }
+          else
+            super(*args, &block)
+          end
+        end
+      end
+
+      ASYNC_METHODS.each { |m| define_async_method(self, m) }
+      ASYNC_BLOCK_METHODS.each { |m| define_async_block_method(self, m) }
+      ASYNC_ARGS_OR_BLOCK_METHODS.each { |m| define_async_args_or_block_method(self, m) }
+
+      def async
+        cached_dataset(:_async) { clone(async: true) }
+      end
+
+      def sync
+        cached_dataset(:_sync) { clone(async: false) }
+      end
+    end
+  end
+
+  Database.register_extension(:concurrent_thread_pool, Database::ConcurrentThreadPool::DatabaseMethods)
+end

--- a/lib/sequel/extensions/concurrent_thread_pool.rb
+++ b/lib/sequel/extensions/concurrent_thread_pool.rb
@@ -27,7 +27,7 @@ module Sequel
       def initialize(executor, &block)
         super()
 
-        @future = Concurrent::Future.execute(executor: executor, &block)
+        @future = Concurrent::Promises.future_on(executor, &block)
       end
 
       def __value
@@ -74,24 +74,30 @@ module Sequel
     end
 
     module DatabaseMethods
-      def self.extended(db)
-        db.instance_exec do
-          case pool.pool_type
-          when :single, :sharded_single
-            raise Error, "cannot load async_thread_pool extension " \
-                         "if using single or sharded_single connection pool"
+      class << self
+        def make_finalizer(executor) = proc { executor.shutdown }
+
+        def extended(db)
+          db.instance_exec do
+            case pool.pool_type
+            when :single, :sharded_single
+              raise Error, "cannot load concurrent_thread_pool extension " \
+                           "if using single or sharded_single connection pool"
+            end
+
+            executor, owned = choose_executor(opts)
+            proxy_klass =
+              typecast_value_boolean(opts[:preempt_async_thread]) ? PreemptableProxy : Proxy
+
+            define_singleton_method(:async_job_class) { proxy_klass }
+            define_singleton_method(:async_thread_executor) { executor }
+
+            finalizer =
+              Sequel::Database::ConcurrentThreadPool::DatabaseMethods.make_finalizer(executor)
+            ObjectSpace.define_finalizer(db, finalizer) if owned
+
+            extend_datasets(DatasetMethods)
           end
-
-          executor, owned = choose_executor(opts)
-          proxy_klass =
-            typecast_value_boolean(opts[:preempt_async_thread]) ? PreemptableProxy : Proxy
-
-          define_singleton_method(:async_job_class) { proxy_klass }
-          define_singleton_method(:async_thread_executor) { executor }
-
-          ObjectSpace.define_finalizer(db, proc { executor.shutdown }) if owned
-
-          extend_datasets(DatasetMethods)
         end
       end
 

--- a/lib/sequel/extensions/concurrent_thread_pool.rb
+++ b/lib/sequel/extensions/concurrent_thread_pool.rb
@@ -5,16 +5,11 @@ require "concurrent"
 module Sequel
   # https://github.com/jeremyevans/sequel/blob/master/lib/sequel/extensions/async_thread_pool.rb
   module Database::ConcurrentThreadPool
-
     # Base proxy: delegates all method calls to the resolved async value.
     class BaseProxy < BasicObject
-      def method_missing(*args, &block)
-        __value.public_send(*args, &block)
+      def method_missing(...)
+        __value.public_send(...)
       end
-
-      # :nocov:
-      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
-      # :nocov:
 
       def respond_to_missing?(*args)
         __value.respond_to?(*args)
@@ -30,7 +25,9 @@ module Sequel
     # Default proxy: schedules block via Concurrent::Future, blocks on first access.
     class Proxy < BaseProxy
       def initialize(executor, &block)
-        @future = ::Concurrent::Future.execute(executor: executor, &block)
+        super()
+
+        @future = Concurrent::Future.execute(executor: executor, &block)
       end
 
       def __value
@@ -41,7 +38,9 @@ module Sequel
     # Preemptable proxy: calling thread runs the block if the pool hasn't started it yet.
     class PreemptableProxy < BaseProxy
       def initialize(executor, &block)
-        @mutex = ::Mutex.new
+        super()
+
+        @mutex = Mutex.new
         @block = block
         @done = false
         @result = nil
@@ -67,8 +66,8 @@ module Sequel
 
       def __execute
         @result = @block.call
-      rescue ::Exception => e
-        @error = e
+      rescue StandardError => error
+        @error = error
       ensure
         @done = true
       end
@@ -79,25 +78,13 @@ module Sequel
         db.instance_exec do
           case pool.pool_type
           when :single, :sharded_single
-            raise Error, "cannot load async_thread_pool extension if using single or sharded_single connection pool"
+            raise Error, "cannot load async_thread_pool extension " \
+                         "if using single or sharded_single connection pool"
           end
 
-          executor, owned = if opts[:async_thread_executor]
-            [opts[:async_thread_executor], false]
-          elsif opts[:num_async_threads]
-            num = typecast_value_integer(opts[:num_async_threads])
-            raise Error, "must have positive number for num_async_threads" if num <= 0
-            [::Concurrent::ThreadPoolExecutor.new(
-              min_threads: num,
-              max_threads: num,
-              max_queue: 0,
-              fallback_policy: :abort,
-            ), true]
-          else
-            [::Concurrent.global_io_executor, false]
-          end
-
-          proxy_klass = typecast_value_boolean(opts[:preempt_async_thread]) ? PreemptableProxy : Proxy
+          executor, owned = choose_executor(opts)
+          proxy_klass =
+            typecast_value_boolean(opts[:preempt_async_thread]) ? PreemptableProxy : Proxy
 
           define_singleton_method(:async_job_class) { proxy_klass }
           define_singleton_method(:async_thread_executor) { executor }
@@ -110,24 +97,42 @@ module Sequel
 
       private
 
+      def choose_executor(opts)
+        if opts[:async_thread_executor]
+          [opts[:async_thread_executor], false]
+        elsif opts[:num_async_threads]
+          num = typecast_value_integer(opts[:num_async_threads])
+          raise Error, "must have positive number for num_async_threads" if num <= 0
+          [Concurrent::ThreadPoolExecutor.new(
+            min_threads: num,
+            max_threads: num,
+            max_queue: 0,
+            fallback_policy: :abort,
+          ), true]
+        else
+          [Concurrent.global_io_executor, false]
+        end
+      end
+
       def async_run(&block)
         async_job_class.new(async_thread_executor, &block)
       end
     end
 
-    ASYNC_METHODS = (
+    ASYNC_METHODS = ((
       [:all?, :any?, :drop, :entries, :grep_v, :include?, :inject, :member?, :minmax,
-       :none?, :one?, :reduce, :sort, :take, :tally, :to_a, :to_h, :uniq, :zip] & Enumerable.instance_methods
-    ) + (Dataset::ACTION_METHODS - [:map, :paged_each])
+       :none?, :one?, :reduce, :sort, :take, :tally, :to_a, :to_h, :uniq, :zip] &
+        Enumerable.instance_methods
+    ) + (Dataset::ACTION_METHODS - [:map, :paged_each])).freeze
 
-    ASYNC_BLOCK_METHODS = (
+    ASYNC_BLOCK_METHODS = ((
       [:collect, :collect_concat, :detect, :drop_while, :each_cons, :each_entry, :each_slice,
        :each_with_index, :each_with_object, :filter_map, :find, :find_all, :find_index,
        :flat_map, :max_by, :min_by, :minmax_by, :partition, :reject, :reverse_each,
        :sort_by, :take_while] & Enumerable.instance_methods
-    ) + [:paged_each]
+    ) + [:paged_each]).freeze
 
-    ASYNC_ARGS_OR_BLOCK_METHODS = [:map]
+    ASYNC_ARGS_OR_BLOCK_METHODS = [:map].freeze
 
     module DatasetMethods
       def self.define_async_method(mod, method)
@@ -177,5 +182,7 @@ module Sequel
     end
   end
 
-  Database.register_extension(:concurrent_thread_pool, Database::ConcurrentThreadPool::DatabaseMethods)
+  Database.register_extension(
+    :concurrent_thread_pool, Database::ConcurrentThreadPool::DatabaseMethods
+  )
 end

--- a/lib/sequel/extensions/concurrent_thread_pool.rb
+++ b/lib/sequel/extensions/concurrent_thread_pool.rb
@@ -106,8 +106,9 @@ module Sequel
       def choose_executor(opts)
         if opts[:async_thread_executor]
           [opts[:async_thread_executor], false]
-        elsif opts[:num_async_threads]
-          num = typecast_value_integer(opts[:num_async_threads])
+        else
+          num = opts[:num_async_threads] ? typecast_value_integer(opts[:num_async_threads]) :
+                                Integer(opts[:max_connections] || 4)
           raise Error, "must have positive number for num_async_threads" if num <= 0
           [Concurrent::ThreadPoolExecutor.new(
             min_threads: num,
@@ -115,8 +116,6 @@ module Sequel
             max_queue: 0,
             fallback_policy: :abort,
           ), true]
-        else
-          [Concurrent.global_io_executor, false]
         end
       end
 

--- a/lib/sequel/plugins/concurrent_thread_pool_eager_loading.rb
+++ b/lib/sequel/plugins/concurrent_thread_pool_eager_loading.rb
@@ -16,7 +16,7 @@ module Sequel
     #   Album.plugin :concurrent_thread_pool_eager_loading, always: true
     module ConcurrentThreadPoolEagerLoading
       def self.configure(mod, opts = OPTS)
-        if opts.has_key?(:always)
+        if opts.key?(:always)
           mod.instance_variable_set(:@always_eager_load_concurrently, opts[:always])
         end
       end
@@ -54,19 +54,19 @@ module Sequel
           return super if !eager_load_concurrently? || eager_load_data.length < 2
 
           mutex = Mutex.new
-          eager_load_data.each_value do |eo|
-            eo[:mutex] = mutex
+          eager_load_data.each_value do |elo|
+            elo[:mutex] = mutex
           end
 
           super.each do |v|
-            if Sequel::Database::ConcurrentThreadPool::BaseProxy === v
+            if v.is_a?(Sequel::Database::ConcurrentThreadPool::BaseProxy)
               v.__value
             end
           end
         end
 
-        def perform_eager_load(loader, eo)
-          eo[:mutex] ? db.send(:async_run) { super } : super
+        def perform_eager_load(loader, elo)
+          elo[:mutex] ? db.send(:async_run) { super } : super
         end
       end
     end

--- a/lib/sequel/plugins/concurrent_thread_pool_eager_loading.rb
+++ b/lib/sequel/plugins/concurrent_thread_pool_eager_loading.rb
@@ -59,7 +59,7 @@ module Sequel
           end
 
           super.each do |v|
-            if v.is_a?(Sequel::Database::ConcurrentThreadPool::BaseProxy)
+            if Sequel::Database::ConcurrentThreadPool::BaseProxy === v # rubocop:disable Style/CaseEquality
               v.__value
             end
           end

--- a/lib/sequel/plugins/concurrent_thread_pool_eager_loading.rb
+++ b/lib/sequel/plugins/concurrent_thread_pool_eager_loading.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Sequel
+  module Plugins
+    # Concurrent eager loading using concurrent_thread_pool extension.
+    # Adapted from Sequel's built-in concurrent_eager_loading plugin but uses
+    # our concurrent_thread_pool extension instead of async_thread_pool.
+    #
+    # Usage:
+    #
+    #   DB.extension(:concurrent_thread_pool)
+    #   Album.plugin :concurrent_thread_pool_eager_loading
+    #   Album.eager_load_concurrently.eager(:artist, :genre, :tracks).all
+    #
+    #   # Always concurrent by default:
+    #   Album.plugin :concurrent_thread_pool_eager_loading, always: true
+    module ConcurrentThreadPoolEagerLoading
+      def self.configure(mod, opts = OPTS)
+        if opts.has_key?(:always)
+          mod.instance_variable_set(:@always_eager_load_concurrently, opts[:always])
+        end
+      end
+
+      module ClassMethods
+        Plugins.inherited_instance_variables(self, :@always_eager_load_concurrently => nil)
+        Plugins.def_dataset_methods(self, [:eager_load_concurrently, :eager_load_serially])
+
+        def always_eager_load_concurrently?
+          @always_eager_load_concurrently
+        end
+      end
+
+      module DatasetMethods
+        def eager_load_concurrently
+          cached_dataset(:_eager_load_concurrently) do
+            clone(eager_load_concurrently: true)
+          end
+        end
+
+        def eager_load_serially
+          cached_dataset(:_eager_load_serially) do
+            clone(eager_load_concurrently: false)
+          end
+        end
+
+        private
+
+        def eager_load_concurrently?
+          v = @opts[:eager_load_concurrently]
+          v.nil? ? model.always_eager_load_concurrently? : v
+        end
+
+        def perform_eager_loads(eager_load_data)
+          return super if !eager_load_concurrently? || eager_load_data.length < 2
+
+          mutex = Mutex.new
+          eager_load_data.each_value do |eo|
+            eo[:mutex] = mutex
+          end
+
+          super.each do |v|
+            if Sequel::Database::ConcurrentThreadPool::BaseProxy === v
+              v.__value
+            end
+          end
+        end
+
+        def perform_eager_load(loader, eo)
+          eo[:mutex] ? db.send(:async_run) { super } : super
+        end
+      end
+    end
+  end
+end

--- a/spec/extensions/concurrent_thread_pool_spec.rb
+++ b/spec/extensions/concurrent_thread_pool_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+ASYNC_DB_URL = ENV.fetch("DB_URL", "postgres:///sequel_plugins")
+
+def make_concurrent_db(**opts)
+  Sequel.connect(ASYNC_DB_URL, **opts).tap { |d| d.extension(:concurrent_thread_pool) }
+end
+
+RSpec.describe "concurrent_thread_pool extension" do
+  let(:db) { make_concurrent_db(**db_opts) }
+  let(:db_opts) { {} }
+
+  after { db.disconnect rescue nil }
+
+  describe "executor configuration" do
+    context "default (no options)" do
+      it "uses global_io_executor" do
+        expect(db.async_thread_executor).to eq(Concurrent.global_io_executor)
+      end
+    end
+
+    context "with num_async_threads:" do
+      let(:db_opts) { { num_async_threads: 3 } }
+
+      it "creates dedicated ThreadPoolExecutor" do
+        expect(db.async_thread_executor).to be_a(Concurrent::ThreadPoolExecutor)
+        expect(db.async_thread_executor).not_to eq(Concurrent.global_io_executor)
+      end
+
+      it "respects the thread count" do
+        expect(db.async_thread_executor.max_length).to eq(3)
+      end
+    end
+
+    context "with async_thread_executor:" do
+      let(:custom_executor) { Concurrent.global_fast_executor }
+      let(:db_opts) { { async_thread_executor: custom_executor } }
+
+      it "uses provided executor" do
+        expect(db.async_thread_executor).to eq(custom_executor)
+      end
+    end
+  end
+
+  describe "loading errors" do
+    it "raises on single_threaded connection pool" do
+      d = Sequel.connect(ASYNC_DB_URL, single_threaded: true)
+      expect { d.extension(:concurrent_thread_pool) }.to raise_error(Sequel::Error, /single/)
+    ensure
+      d&.disconnect
+    end
+
+    it "raises on num_async_threads: 0" do
+      d = Sequel.connect(ASYNC_DB_URL, num_async_threads: 0)
+      expect { d.extension(:concurrent_thread_pool) }.to raise_error(Sequel::Error, /positive/)
+    ensure
+      d&.disconnect
+    end
+  end
+
+  describe "Dataset#async" do
+    it "returns a proxy (not the resolved value)" do
+      result = db.fetch("SELECT 1 AS val").async.all
+      # be_a delegates through method_missing on BasicObject, so compare object identity
+      expect(result.__id__).not_to eq(result.__value.__id__)
+    end
+
+    it "proxy resolves via __value" do
+      result = db.fetch("SELECT 1 AS val").async.all
+      expect(result.__value).to eq([{ val: 1 }])
+    end
+
+    it "proxy delegates method calls to resolved value" do
+      result = db.fetch("SELECT 1 AS val").async.all
+      expect(result.first).to eq({ val: 1 })
+      expect(result.length).to eq(1)
+    end
+
+    it "proxy responds_to? based on resolved value" do
+      result = db.fetch("SELECT 1 AS val").async.all
+      expect(result.respond_to?(:first)).to be(true)
+      expect(result.respond_to?(:nonexistent_method_xyz)).to be(false)
+    end
+
+    it "works with first" do
+      result = db.fetch("SELECT 1 AS val").async.first
+      expect(result[:val]).to eq(1)
+    end
+
+    it "works with map" do
+      result = db.fetch("SELECT generate_series AS n FROM generate_series(1, 3)").async.map(:n)
+      expect(result.__value).to eq([1, 2, 3])
+    end
+
+    it "works with count" do
+      result = db.fetch("SELECT generate_series FROM generate_series(1, 5)").async.count
+      expect(result.__value).to eq(5)
+    end
+  end
+
+  describe "Dataset#sync" do
+    it "returns non-proxy result" do
+      result = db.fetch("SELECT 1 AS val").async.sync.all
+      expect(result).to eq([{ val: 1 }])
+    end
+
+    it "disables async on cloned dataset" do
+      async_ds = db.fetch("SELECT 1 AS val").async
+      expect(async_ds.opts[:async]).to be(true)
+      expect(async_ds.sync.opts[:async]).to be(false)
+    end
+  end
+
+  describe "exception propagation" do
+    it "re-raises DB errors on value access" do
+      result = db.fetch("SELECT 1/0").async.all
+      expect { result.__value }.to raise_error(Sequel::DatabaseError)
+    end
+
+    it "re-raises on delegated method call" do
+      result = db.fetch("SELECT 1/0").async.all
+      expect { result.first }.to raise_error(Sequel::DatabaseError)
+    end
+  end
+
+  describe "concurrent execution" do
+    it "runs multiple queries in parallel" do
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      r1 = db.fetch("SELECT pg_sleep(0.3), 1 AS n").async.first
+      r2 = db.fetch("SELECT pg_sleep(0.3), 2 AS n").async.first
+      r3 = db.fetch("SELECT pg_sleep(0.3), 3 AS n").async.first
+
+      expect(r1[:n]).to eq(1)
+      expect(r2[:n]).to eq(2)
+      expect(r3[:n]).to eq(3)
+
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+      expect(elapsed).to be < 0.7
+    end
+  end
+
+  describe "thread safety of proxy" do
+    it "__value returns same result across concurrent callers" do
+      proxy = db.fetch("SELECT 1 AS val").async.all
+
+      results = Array.new(8) { Thread.new { proxy.__value } }.map(&:value)
+      expect(results).to all(eq([{ val: 1 }]))
+    end
+  end
+
+  describe "with preempt_async_thread option" do
+    let(:db_opts) { { preempt_async_thread: true } }
+
+    it "resolves correctly" do
+      result = db.fetch("SELECT 1 AS val").async.all
+      expect(result.first).to eq({ val: 1 })
+    end
+
+    it "re-raises exceptions" do
+      result = db.fetch("SELECT 1/0").async.all
+      expect { result.__value }.to raise_error(Sequel::DatabaseError)
+    end
+
+    it "returns same result across concurrent callers" do
+      proxy = db.fetch("SELECT 1 AS val").async.all
+
+      results = Array.new(8) { Thread.new { proxy.__value } }.map(&:value)
+      expect(results).to all(eq([{ val: 1 }]))
+    end
+  end
+
+  describe "async_job_class" do
+    it "is Proxy by default" do
+      expect(db.async_job_class).to eq(Sequel::Database::ConcurrentThreadPool::Proxy)
+    end
+
+    context "with preempt_async_thread: true" do
+      let(:db_opts) { { preempt_async_thread: true } }
+
+      it "is PreemptableProxy" do
+        expect(db.async_job_class).to eq(Sequel::Database::ConcurrentThreadPool::PreemptableProxy)
+      end
+    end
+  end
+end

--- a/spec/extensions/concurrent_thread_pool_spec.rb
+++ b/spec/extensions/concurrent_thread_pool_spec.rb
@@ -16,8 +16,9 @@ RSpec.describe "concurrent_thread_pool extension" do
 
   describe "executor configuration" do
     context "default (no options)" do
-      it "uses global_io_executor" do
-        expect(db.async_thread_executor).to eq(Concurrent.global_io_executor)
+      it "uses 4 threads" do
+        expect(db.async_thread_executor).to be_a(Concurrent::ThreadPoolExecutor)
+        expect(db.async_thread_executor.max_length).to eq(4)
       end
     end
 
@@ -26,7 +27,6 @@ RSpec.describe "concurrent_thread_pool extension" do
 
       it "creates dedicated ThreadPoolExecutor" do
         expect(db.async_thread_executor).to be_a(Concurrent::ThreadPoolExecutor)
-        expect(db.async_thread_executor).not_to eq(Concurrent.global_io_executor)
       end
 
       it "respects the thread count" do

--- a/spec/plugins/concurrent_thread_pool_eager_loading_spec.rb
+++ b/spec/plugins/concurrent_thread_pool_eager_loading_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+CONCURRENT_EAGER_DB_URL = ENV.fetch("DB_URL", "postgres:///sequel_plugins")
+
+def make_concurrent_eager_db
+  Sequel.connect(CONCURRENT_EAGER_DB_URL).tap { |d| d.extension(:concurrent_thread_pool) }
+end
+
+RSpec.describe "concurrent_thread_pool_eager_loading plugin" do
+  let(:db) { make_concurrent_eager_db }
+
+  before(:all) do
+    setup_db = make_concurrent_eager_db
+
+    setup_db.create_table(:cel_artists) do
+      primary_key :id
+      String :name, null: false
+    end
+
+    setup_db.create_table(:cel_albums) do
+      primary_key :id
+      String :title, null: false
+      foreign_key :artist_id, :cel_artists
+    end
+
+    setup_db.create_table(:cel_tracks) do
+      primary_key :id
+      String :name, null: false
+      foreign_key :album_id, :cel_albums
+    end
+
+    artist = setup_db[:cel_artists].returning(:id).insert(name: "Artist A").first[:id]
+    album1 = setup_db[:cel_albums].returning(:id).insert(title: "Album 1", artist_id: artist).first[:id]
+    album2 = setup_db[:cel_albums].returning(:id).insert(title: "Album 2", artist_id: artist).first[:id]
+    setup_db[:cel_tracks].insert(name: "Track 1", album_id: album1)
+    setup_db[:cel_tracks].insert(name: "Track 2", album_id: album1)
+    setup_db[:cel_tracks].insert(name: "Track 3", album_id: album2)
+
+    setup_db.disconnect
+  end
+
+  after(:all) do
+    cleanup_db = make_concurrent_eager_db
+    cleanup_db.drop_table(:cel_tracks, :cel_albums, :cel_artists)
+    cleanup_db.disconnect
+  end
+
+  after { db.disconnect rescue nil }
+
+  let(:artist_class) do
+    klass = Class.new(Sequel::Model(db[:cel_artists]))
+    klass.plugin :concurrent_thread_pool_eager_loading
+    klass.one_to_many :albums, class: album_class, key: :artist_id
+    klass
+  end
+
+  let(:album_class) do
+    klass = Class.new(Sequel::Model(db[:cel_albums]))
+    klass.plugin :concurrent_thread_pool_eager_loading
+    klass.many_to_one :artist, class_name: "Artist"
+    klass.one_to_many :tracks, class: track_class, key: :album_id
+    klass
+  end
+
+  let(:track_class) do
+    Class.new(Sequel::Model(db[:cel_tracks]))
+  end
+
+  describe "#eager_load_concurrently" do
+    it "loads multiple associations concurrently" do
+      albums = album_class.eager_load_concurrently.eager(:tracks).all
+      expect(albums.length).to eq(2)
+      expect(albums.flat_map { |a| a.tracks }.length).to eq(3)
+    end
+
+    it "sets eager_load_concurrently option on dataset" do
+      ds = album_class.eager_load_concurrently
+      expect(ds.opts[:eager_load_concurrently]).to be(true)
+    end
+  end
+
+  describe "#eager_load_serially" do
+    it "loads associations serially even when always: true" do
+      album_class.plugin :concurrent_thread_pool_eager_loading, always: true
+      albums = album_class.eager_load_serially.eager(:tracks).all
+      expect(albums.length).to eq(2)
+      expect(albums.flat_map { |a| a.tracks }.length).to eq(3)
+    end
+
+    it "sets eager_load_concurrently option to false" do
+      ds = album_class.eager_load_serially
+      expect(ds.opts[:eager_load_concurrently]).to be(false)
+    end
+  end
+
+  describe "always: true option" do
+    before { album_class.plugin :concurrent_thread_pool_eager_loading, always: true }
+
+    it "makes concurrent loading the default" do
+      expect(album_class.always_eager_load_concurrently?).to be(true)
+    end
+
+    it "loads associations correctly without explicit eager_load_concurrently" do
+      albums = album_class.eager(:tracks).all
+      expect(albums.flat_map { |a| a.tracks }.length).to eq(3)
+    end
+  end
+
+  describe "single association" do
+    it "does not use threads (no mutex set)" do
+      # Single association: perform_eager_loads short-circuits, no concurrent execution
+      albums = album_class.eager_load_concurrently.eager(:tracks).all
+      expect(albums.flat_map { |a| a.tracks }.length).to eq(3)
+    end
+  end
+
+  describe "concurrent execution" do
+    it "loads associations correctly when multiple present" do
+      albums = album_class.eager_load_concurrently.eager(:tracks).all
+      artists = artist_class.eager_load_concurrently.eager(:albums).all
+
+      expect(albums.flat_map { |a| a.tracks }.length).to eq(3)
+      expect(artists.flat_map { |a| a.albums }.length).to eq(2)
+    end
+  end
+
+  describe "inheritance" do
+    it "subclass inherits always_eager_load_concurrently setting" do
+      album_class.plugin :concurrent_thread_pool_eager_loading, always: true
+      subclass = Class.new(album_class)
+      expect(subclass.always_eager_load_concurrently?).to be(true)
+    end
+  end
+end

--- a/spec/plugins/concurrent_thread_pool_eager_loading_spec.rb
+++ b/spec/plugins/concurrent_thread_pool_eager_loading_spec.rb
@@ -10,8 +10,24 @@ end
 
 RSpec.describe "concurrent_thread_pool_eager_loading plugin" do
   let(:db) { make_concurrent_eager_db }
+  let(:artist_class) do
+    klass = Class.new(Sequel::Model(db[:cel_artists]))
+    klass.plugin :concurrent_thread_pool_eager_loading
+    klass.one_to_many :albums, class: album_class, key: :artist_id
+    klass
+  end
+  let(:album_class) do
+    klass = Class.new(Sequel::Model(db[:cel_albums]))
+    klass.plugin :concurrent_thread_pool_eager_loading
+    klass.many_to_one :artist, class_name: "Artist"
+    klass.one_to_many :tracks, class: track_class, key: :album_id
+    klass
+  end
+  let(:track_class) do
+    Class.new(Sequel::Model(db[:cel_tracks]))
+  end
 
-  before(:all) do
+  before do
     setup_db = make_concurrent_eager_db
 
     setup_db.create_table(:cel_artists) do
@@ -32,8 +48,10 @@ RSpec.describe "concurrent_thread_pool_eager_loading plugin" do
     end
 
     artist = setup_db[:cel_artists].returning(:id).insert(name: "Artist A").first[:id]
-    album1 = setup_db[:cel_albums].returning(:id).insert(title: "Album 1", artist_id: artist).first[:id]
-    album2 = setup_db[:cel_albums].returning(:id).insert(title: "Album 2", artist_id: artist).first[:id]
+    album1 = setup_db[:cel_albums].returning(:id)
+                                  .insert(title: "Album 1", artist_id: artist).first[:id]
+    album2 = setup_db[:cel_albums].returning(:id)
+                                  .insert(title: "Album 2", artist_id: artist).first[:id]
     setup_db[:cel_tracks].insert(name: "Track 1", album_id: album1)
     setup_db[:cel_tracks].insert(name: "Track 2", album_id: album1)
     setup_db[:cel_tracks].insert(name: "Track 3", album_id: album2)
@@ -41,7 +59,7 @@ RSpec.describe "concurrent_thread_pool_eager_loading plugin" do
     setup_db.disconnect
   end
 
-  after(:all) do
+  after do
     cleanup_db = make_concurrent_eager_db
     cleanup_db.drop_table(:cel_tracks, :cel_albums, :cel_artists)
     cleanup_db.disconnect
@@ -49,30 +67,11 @@ RSpec.describe "concurrent_thread_pool_eager_loading plugin" do
 
   after { db.disconnect rescue nil }
 
-  let(:artist_class) do
-    klass = Class.new(Sequel::Model(db[:cel_artists]))
-    klass.plugin :concurrent_thread_pool_eager_loading
-    klass.one_to_many :albums, class: album_class, key: :artist_id
-    klass
-  end
-
-  let(:album_class) do
-    klass = Class.new(Sequel::Model(db[:cel_albums]))
-    klass.plugin :concurrent_thread_pool_eager_loading
-    klass.many_to_one :artist, class_name: "Artist"
-    klass.one_to_many :tracks, class: track_class, key: :album_id
-    klass
-  end
-
-  let(:track_class) do
-    Class.new(Sequel::Model(db[:cel_tracks]))
-  end
-
   describe "#eager_load_concurrently" do
     it "loads multiple associations concurrently" do
       albums = album_class.eager_load_concurrently.eager(:tracks).all
       expect(albums.length).to eq(2)
-      expect(albums.flat_map { |a| a.tracks }.length).to eq(3)
+      expect(albums.flat_map(&:tracks).length).to eq(3)
     end
 
     it "sets eager_load_concurrently option on dataset" do
@@ -86,7 +85,7 @@ RSpec.describe "concurrent_thread_pool_eager_loading plugin" do
       album_class.plugin :concurrent_thread_pool_eager_loading, always: true
       albums = album_class.eager_load_serially.eager(:tracks).all
       expect(albums.length).to eq(2)
-      expect(albums.flat_map { |a| a.tracks }.length).to eq(3)
+      expect(albums.flat_map(&:tracks).length).to eq(3)
     end
 
     it "sets eager_load_concurrently option to false" do
@@ -104,7 +103,7 @@ RSpec.describe "concurrent_thread_pool_eager_loading plugin" do
 
     it "loads associations correctly without explicit eager_load_concurrently" do
       albums = album_class.eager(:tracks).all
-      expect(albums.flat_map { |a| a.tracks }.length).to eq(3)
+      expect(albums.flat_map(&:tracks).length).to eq(3)
     end
   end
 
@@ -112,7 +111,7 @@ RSpec.describe "concurrent_thread_pool_eager_loading plugin" do
     it "does not use threads (no mutex set)" do
       # Single association: perform_eager_loads short-circuits, no concurrent execution
       albums = album_class.eager_load_concurrently.eager(:tracks).all
-      expect(albums.flat_map { |a| a.tracks }.length).to eq(3)
+      expect(albums.flat_map(&:tracks).length).to eq(3)
     end
   end
 
@@ -121,8 +120,8 @@ RSpec.describe "concurrent_thread_pool_eager_loading plugin" do
       albums = album_class.eager_load_concurrently.eager(:tracks).all
       artists = artist_class.eager_load_concurrently.eager(:albums).all
 
-      expect(albums.flat_map { |a| a.tracks }.length).to eq(3)
-      expect(artists.flat_map { |a| a.albums }.length).to eq(2)
+      expect(albums.flat_map(&:tracks).length).to eq(3)
+      expect(artists.flat_map(&:albums).length).to eq(2)
     end
   end
 

--- a/umbrellio-sequel-plugins.gemspec
+++ b/umbrellio-sequel-plugins.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "sequel"
+  spec.add_runtime_dependency "concurrent-ruby"
 end

--- a/umbrellio-sequel-plugins.gemspec
+++ b/umbrellio-sequel-plugins.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name = "umbrellio-sequel-plugins"
-  spec.version = "0.17.2"
+  spec.version = "0.18.0"
   spec.required_ruby_version = ">= 3.0"
 
   spec.authors = ["Team Umbrellio"]

--- a/umbrellio-sequel-plugins.gemspec
+++ b/umbrellio-sequel-plugins.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "sequel"
   spec.add_runtime_dependency "concurrent-ruby"
+  spec.add_runtime_dependency "sequel"
 end


### PR DESCRIPTION
Original async_thread_pool in sequel uses raw threads. It has problems with puma and rails. I made it use concurrent ruby default IO executor.