### PR TITLE
Implement async_job_wrapper functionality in the concurrent_thread_pool extension to allow custom job wrapping

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    umbrellio-sequel-plugins (0.19.0)
+    umbrellio-sequel-plugins (0.20.0)
       concurrent-ruby
       sequel
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $ bundle
 - [`Set Local`](#set-local)
 - [`Migration Transaction Options`](#migration-transaction-options)
 - [`Fibered Connection Pool`](#fibered-connection-pool)
+- [`Concurrent Thread Pool`](#concurrent-thread-pool)
 
 # Plugins
 
@@ -270,6 +271,55 @@ Put this code before your application connects to database
 ```ruby
 Sequel.extension(:fiber_concurrency) # Default Sequel extension for fiber isolation level
 Sequel.extension(:fibered_connection_pool)
+```
+
+## Concurrent Thread Pool
+
+Async query execution on a [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) thread pool (alternative to Sequel's built-in `async_thread_pool`).
+
+Enable (after connecting; not with `single_threaded` / `sharded_single` pools):
+
+```ruby
+DB.extension(:concurrent_thread_pool)
+```
+
+Options (pass to `Sequel.connect` before loading the extension):
+
+- `:num_async_threads` — pool size (defaults to `:max_connections`, usually 4)
+- `:async_thread_executor` — reuse an existing Concurrent executor
+- `:preempt_async_thread` — allow the calling thread to run the job if the pool hasn't started it yet
+- `:async_job_wrapper` — callable that wraps each async job (see OpenTelemetry below)
+
+Example:
+
+```ruby
+foos = DB[:foos].async.all
+bars = DB[:bars].async.all
+# both queries run concurrently; access forces wait
+foos.length
+bars.length
+```
+
+### OpenTelemetry
+
+Context is **not** propagated automatically. Pass `:async_job_wrapper` so each `async_run` job runs under the calling thread's OpenTelemetry context:
+
+```ruby
+otel_wrapper = lambda do |&block|
+  ctx = OpenTelemetry::Context.current
+
+  if ctx.equal?(OpenTelemetry::Context::ROOT)
+    block
+  else
+    -> { OpenTelemetry::Context.with_current(ctx, &block) }
+  end
+end
+
+DB = Sequel.connect(ENV["DATABASE_URL"], async_job_wrapper: otel_wrapper)
+DB.extension(:concurrent_thread_pool)
+
+# Dataset#async and Model eager loading both go through async_run
+DB[:users].async.all
 ```
 
 ## AttrEncrypted

--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ bars.length
 
 ### OpenTelemetry
 
+**Migrating from 0.19.0:** automatic OpenTelemetry context propagation was removed in 0.20.0. Without `:async_job_wrapper`, async workers no longer inherit the calling thread's span context — configure the wrapper below to restore it.
+
 Context is **not** propagated automatically. Pass `:async_job_wrapper` so each `async_run` job runs under the calling thread's OpenTelemetry context:
 
 ```ruby

--- a/lib/sequel/extensions/concurrent_thread_pool.rb
+++ b/lib/sequel/extensions/concurrent_thread_pool.rb
@@ -120,12 +120,9 @@ module Sequel
       end
 
       def async_run(&)
-        otel_context = OpenTelemetry::Context.current if defined?(OpenTelemetry::Context)
-
-        if otel_context && !otel_context.equal?(OpenTelemetry::Context::ROOT)
-          async_job_class.new(async_thread_executor) do
-            OpenTelemetry::Context.with_current(otel_context, &)
-          end
+        if opts[:async_job_wrapper]
+          wrapped_block = opts[:async_job_wrapper].call(&)
+          async_job_class.new(async_thread_executor, &wrapped_block)
         else
           async_job_class.new(async_thread_executor, &)
         end

--- a/lib/sequel/extensions/concurrent_thread_pool.rb
+++ b/lib/sequel/extensions/concurrent_thread_pool.rb
@@ -85,6 +85,10 @@ module Sequel
                            "if using single or sharded_single connection pool"
             end
 
+            if (wrapper = opts[:async_job_wrapper]) && !wrapper.respond_to?(:call)
+              raise Error, "async_job_wrapper must respond to call"
+            end
+
             executor, owned = choose_executor(opts)
             proxy_klass =
               typecast_value_boolean(opts[:preempt_async_thread]) ? PreemptableProxy : Proxy
@@ -119,13 +123,9 @@ module Sequel
         end
       end
 
-      def async_run(&)
-        if opts[:async_job_wrapper]
-          wrapped_block = opts[:async_job_wrapper].call(&)
-          async_job_class.new(async_thread_executor, &wrapped_block)
-        else
-          async_job_class.new(async_thread_executor, &)
-        end
+      def async_run(&block)
+        block = opts[:async_job_wrapper].call(&block) if opts[:async_job_wrapper]
+        async_job_class.new(async_thread_executor, &block)
       end
     end
 

--- a/spec/extensions/concurrent_thread_pool_opentelemetry_spec.rb
+++ b/spec/extensions/concurrent_thread_pool_opentelemetry_spec.rb
@@ -3,9 +3,21 @@
 require "opentelemetry-api"
 require_relative "concurrent_thread_pool_helpers"
 
-RSpec.describe "concurrent_thread_pool extension OpenTelemetry context propagation" do
-  let(:db) { make_concurrent_db }
+RSpec.describe "concurrent_thread_pool extension OpenTelemetry via async_job_wrapper" do
   let(:otel_key) { OpenTelemetry::Context.create_key("sequel-test") }
+  let(:otel_wrapper) do
+    lambda do |&block|
+      ctx = OpenTelemetry::Context.current
+
+      if ctx.equal?(OpenTelemetry::Context::ROOT)
+        block
+      else
+        -> { OpenTelemetry::Context.with_current(ctx, &block) }
+      end
+    end
+  end
+  let(:db) { make_concurrent_db(**db_opts) }
+  let(:db_opts) { { async_job_wrapper: otel_wrapper } }
 
   after { db.disconnect rescue nil }
 
@@ -15,15 +27,6 @@ RSpec.describe "concurrent_thread_pool extension OpenTelemetry context propagati
     db.send(:async_run) { captured = OpenTelemetry::Context.current.value(otel_key) }.__value
 
     expect(captured).to be_nil
-  end
-
-  it "does not error when OpenTelemetry is defined without Context" do
-    db = make_concurrent_db
-    stub_const("OpenTelemetry", Object.new)
-
-    expect { db.send(:async_run) { :ok }.__value }.not_to raise_error
-  ensure
-    db.disconnect rescue nil
   end
 
   it "propagates calling-thread context to worker thread" do
@@ -37,7 +40,7 @@ RSpec.describe "concurrent_thread_pool extension OpenTelemetry context propagati
   end
 
   context "with single-thread executor" do
-    let(:db) { make_concurrent_db(num_async_threads: 1) }
+    let(:db_opts) { { num_async_threads: 1, async_job_wrapper: otel_wrapper } }
 
     it "restores context in worker thread after block completes" do
       OpenTelemetry::Context.with_value(otel_key, "sentinel") do
@@ -63,6 +66,20 @@ RSpec.describe "concurrent_thread_pool extension OpenTelemetry context propagati
 
       expect { result.__value }.to raise_error(RuntimeError, "boom")
       expect(captured).to eq("sentinel")
+    end
+  end
+
+  context "without async_job_wrapper" do
+    let(:db_opts) { {} }
+
+    it "does not propagate OpenTelemetry context" do
+      captured = :not_set
+
+      OpenTelemetry::Context.with_value(otel_key, "sentinel") do
+        db.send(:async_run) { captured = OpenTelemetry::Context.current.value(otel_key) }.__value
+      end
+
+      expect(captured).to be_nil
     end
   end
 end

--- a/spec/extensions/concurrent_thread_pool_spec.rb
+++ b/spec/extensions/concurrent_thread_pool_spec.rb
@@ -166,6 +166,57 @@ RSpec.describe "concurrent_thread_pool extension" do
     end
   end
 
+  describe "async_job_wrapper" do
+    it "runs block as-is when wrapper is not set" do
+      expect(db.send(:async_run) { :ok }.__value).to eq(:ok)
+    end
+
+    context "with async_job_wrapper:" do
+      let(:wrapper_calls) { [] }
+      let(:wrapper) do
+        lambda do |&block|
+          wrapper_calls << :called
+          marker = Thread.current[:async_job_marker]
+          lambda do
+            Thread.current[:async_job_marker] = marker
+            block.call
+          end
+        end
+      end
+      let(:db_opts) { { async_job_wrapper: wrapper } }
+
+      it "wraps the job before scheduling" do
+        Thread.current[:async_job_marker] = "sentinel"
+        captured = nil
+
+        db.send(:async_run) { captured = Thread.current[:async_job_marker] }.__value
+
+        expect(wrapper_calls).to eq([:called])
+        expect(captured).to eq("sentinel")
+      end
+
+      it "applies wrapper to dataset async methods" do
+        Thread.current[:async_job_marker] = "from-dataset"
+        captured = nil
+
+        db.fetch("SELECT 1 AS val").async.map do |row|
+          captured = Thread.current[:async_job_marker]
+          row[:val]
+        end.__value
+
+        expect(wrapper_calls).to eq([:called])
+        expect(captured).to eq("from-dataset")
+      end
+
+      it "propagates exceptions from wrapped block" do
+        result = db.send(:async_run) { raise "boom" }
+
+        expect { result.__value }.to raise_error(RuntimeError, "boom")
+        expect(wrapper_calls).to eq([:called])
+      end
+    end
+  end
+
   describe "async_job_class" do
     it "is Proxy by default" do
       expect(db.async_job_class).to eq(Sequel::Database::ConcurrentThreadPool::Proxy)

--- a/spec/extensions/concurrent_thread_pool_spec.rb
+++ b/spec/extensions/concurrent_thread_pool_spec.rb
@@ -52,6 +52,14 @@ RSpec.describe "concurrent_thread_pool extension" do
     ensure
       d&.disconnect
     end
+
+    it "raises on non-callable async_job_wrapper" do
+      d = Sequel.connect(ASYNC_DB_URL, async_job_wrapper: Object.new)
+      expect { d.extension(:concurrent_thread_pool) }
+        .to raise_error(Sequel::Error, /async_job_wrapper must respond to call/)
+    ensure
+      d&.disconnect
+    end
   end
 
   describe "Dataset#async" do

--- a/umbrellio-sequel-plugins.gemspec
+++ b/umbrellio-sequel-plugins.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name = "umbrellio-sequel-plugins"
-  spec.version = "0.19.0"
+  spec.version = "0.20.0"
   spec.required_ruby_version = ">= 3.3"
 
   spec.authors = ["Team Umbrellio"]


### PR DESCRIPTION
Hi @tycooon! 

Following up on your longer-term architectural suggestion from PR [#46](https://github.com/umbrellio/umbrellio-sequel-plugins/pull/46), I've added a proper `opts` surface for context propagation instead of relying on per-vendor `defined?` checks.

I added `opts[:async_job_wrapper]` — a generic callable hook that users can configure to propagate ANY context (OpenTelemetry, Sentry, Datadog, etc.) without modifying the gem.

This approach gives users full flexibility while preserving sensible defaults. The gem no longer needs a per-vendor `defined?` ladder — any future integrations can be handled at the application level via `async_job_wrapper`.

## ⚠️ Migration Note (0.19.0 → 0.20.0)

This PR removes the automatic OpenTelemetry context propagation that was briefly introduced in `0.19.0`. 
To prevent silent trace detachment and keep the gem vendor-agnostic, context propagation is now **opt-in** via the new `:async_job_wrapper` option.

If you relied on automatic OTel propagation in `0.19.0`, you must now explicitly pass the wrapper when connecting:

```ruby
otel_wrapper = lambda do |&block|
  ctx = OpenTelemetry::Context.current
  if ctx.equal?(OpenTelemetry::Context::ROOT)
    block
  else
    -> { OpenTelemetry::Context.with_current(ctx, &block) }
  end
end

DB = Sequel.connect(ENV["DATABASE_URL"], async_job_wrapper: otel_wrapper)
DB.extension(:concurrent_thread_pool)

Let me know if it looks ok now after refactoring!